### PR TITLE
[Owners] Minor change in value of status and error message for session APIs.

### DIFF
--- a/source/tests/system/nidcpower_session_tests.cpp
+++ b/source/tests/system/nidcpower_session_tests.cpp
@@ -9,8 +9,8 @@ namespace system {
 
 namespace dcpower = nidcpower_grpc;
 
-const int kTestViErrorRsrcNotFound = -1073807343;
-const char* kTestViErrorRsrcNotFoundMessage = "VISA:  (Hex 0xBFFF0011) Insufficient location information or the device or resource is not present in the system.";
+const int kTestViErrorRsrcNotFound = -1074134944;
+const char* kTestViErrorRsrcNotFoundMessage = "IVI: (Hex 0xBFFA0060) Insufficient location information or resource not present in the system.";
 const char* kTestRsrc = "FakeDevice";
 const char* kOptionsString = "Simulate=1, DriverSetup=Model:4147; BoardType:PXIe";
 const char* kTestSession = "SessionName";


### PR DESCRIPTION
### What does this Pull Request accomplish?

Corrections in the value of status and error message when resource is not found.

### Why should this Pull Request be merged?

Changes in the value:
1) kTestViErrorRsrcNotFound = -1074134944
2) kTestViErrorRsrcNotFoundMessage = "IVI: (Hex 0xBFFA0060) Insufficient location information or resource not present in the system."

### What testing has been done?
Manually ran the tests.
![image](https://user-images.githubusercontent.com/78592845/115568355-d5975600-a2d9-11eb-9ee7-8929d28d4f9b.png)

