### PR TITLE
[Owners] CMakeLists.txt delayloaded dll name changed for nidmm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,8 +192,8 @@ target_link_libraries(ni_grpc_device_server
 
 if(WIN32)
   target_link_libraries(ni_grpc_device_server Delayimp nidmm niScope niswitch nisync)
-  set_target_properties(ni_grpc_device_server PROPERTIES LINK_FLAGS "/DELAYLOAD:nidmm.dll /DELAYLOAD:niScope.dll /DELAYLOAD:niswitch.dll /DELAYLOAD:nisync.dll")
-  set(ni_grpc_device_server CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DELAYLOAD:nidmm.dll /DELAYLOAD:niScope.dll /DELAYLOAD:niswitch.dll /DELAYLOAD:nisync.dll")
+  set_target_properties(ni_grpc_device_server PROPERTIES LINK_FLAGS "/DELAYLOAD:nidmm_64.dll /DELAYLOAD:niScope.dll /DELAYLOAD:niswitch.dll /DELAYLOAD:nisync.dll")
+  set(ni_grpc_device_server CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DELAYLOAD:nidmm_64.dll /DELAYLOAD:niScope.dll /DELAYLOAD:niswitch.dll /DELAYLOAD:nisync.dll")
 endif()
 
 #----------------------------------------------------------------------
@@ -320,8 +320,8 @@ target_link_libraries(SystemTestsRunner
 
 if(WIN32)
     target_link_libraries(SystemTestsRunner Delayimp nidmm niScope niswitch nisync)
-    set_target_properties(SystemTestsRunner PROPERTIES LINK_FLAGS "/DELAYLOAD:nidmm.dll /DELAYLOAD:niScope.dll /DELAYLOAD:niswitch.dll /DELAYLOAD:nisync.dll")
-    set(SystemTestsRunner CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}  /DELAYLOAD:nidmm.dll /DELAYLOAD:niScope.dll /DELAYLOAD:niswitch.dll /DELAYLOAD:nisync.dll")
+    set_target_properties(SystemTestsRunner PROPERTIES LINK_FLAGS "/DELAYLOAD:nidmm_64.dll /DELAYLOAD:niScope.dll /DELAYLOAD:niswitch.dll /DELAYLOAD:nisync.dll")
+    set(SystemTestsRunner CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}  /DELAYLOAD:nidmm_64.dll /DELAYLOAD:niScope.dll /DELAYLOAD:niswitch.dll /DELAYLOAD:nisync.dll")
 endif()
 
 # Hook up different google test runners to CTest


### PR DESCRIPTION
### What does this Pull Request accomplish?

The Delayloaded dll in the CMakeLists.txt file, which earlier was mentioned as nidmm.dll is changed to nidmm_64.dll, which is the correct one

### Why should this Pull Request be merged?

the lib file of nidmm is imported type instead of static like in case of scope, dcpower. So, it requires delayloaded dll for the server exe to run on machine without DMM driver installed. Earlier it was mentioned as nidmm.dll following the convention of others like niScope.dll, niswitch.dll. But on testing the exe on machine without driver, it was found the name is actually nidmm_64.dll. So, that is now fixed.

### What testing has been done?

The generated server exe has been tested on machine without driver and the exe runs properly