### PR TITLE
[Owners] [Tiny] Removing extra space in mako file

### DIFF
--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -219,7 +219,7 @@ one_of_case_prefix = f'{namespace_prefix}{function_name}Request::{PascalFieldNam
       response->mutable_${parameter_name}()->Resize(${size}, 0);
       ${underlying_param_type}* ${parameter_name} = reinterpret_cast<${underlying_param_type}*>(response->mutable_${parameter_name}()->mutable_data());
 %     else:
-      response->mutable_${parameter_name}()->Resize(${size}, 0); 
+      response->mutable_${parameter_name}()->Resize(${size}, 0);
       ${underlying_param_type}* ${parameter_name} = response->mutable_${parameter_name}()->mutable_data();
 %     endif
 %   else:


### PR DESCRIPTION
### What does this Pull Request accomplish?

In one of the previous PR, there was an extra space added to mako file by mistake. This PR removes that extra space.

Note: In that previous PR, only change to mako file was submitted but the effect it had on some of the generated files were not submitted. The confusion happened because in visual studio, it was not showing the diff correctly for that extra space in generated files and hence was missed.

### Why should this Pull Request be merged?

To fix indentation issues, this PR should be submitted.

### What testing has been done?

After this change, generated files during the local build do not have that extra space.
