### PR TITLE
[Owners] Add unit test for ViBoolean[] input parameter

### DIFF
--- a/generated/nifake/nifake.proto
+++ b/generated/nifake/nifake.proto
@@ -19,6 +19,7 @@ service NiFake {
   rpc Abort(AbortRequest) returns (AbortResponse);
   rpc AcceptListOfDurationsInSeconds(AcceptListOfDurationsInSecondsRequest) returns (AcceptListOfDurationsInSecondsResponse);
   rpc BoolArrayOutputFunction(BoolArrayOutputFunctionRequest) returns (BoolArrayOutputFunctionResponse);
+  rpc BoolArrayInputFunction(BoolArrayInputFunctionRequest) returns (BoolArrayInputFunctionResponse);
   rpc DoubleAllTheNums(DoubleAllTheNumsRequest) returns (DoubleAllTheNumsResponse);
   rpc EnumArrayOutputFunction(EnumArrayOutputFunctionRequest) returns (EnumArrayOutputFunctionResponse);
   rpc EnumInputFunctionWithDefaults(EnumInputFunctionWithDefaultsRequest) returns (EnumInputFunctionWithDefaultsResponse);
@@ -138,6 +139,16 @@ message BoolArrayOutputFunctionRequest {
 message BoolArrayOutputFunctionResponse {
   int32 status = 1;
   repeated bool an_array = 2;
+}
+
+message BoolArrayInputFunctionRequest {
+  nidevice_grpc.Session vi = 1;
+  sint32 number_of_elements = 2;
+  repeated bool an_array = 3;
+}
+
+message BoolArrayInputFunctionResponse {
+  int32 status = 1;
 }
 
 message DoubleAllTheNumsRequest {

--- a/generated/nifake/nifake_library.cpp
+++ b/generated/nifake/nifake_library.cpp
@@ -24,6 +24,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.Abort = reinterpret_cast<AbortPtr>(shared_library_.get_function_pointer("niFake_Abort"));
   function_pointers_.AcceptListOfDurationsInSeconds = reinterpret_cast<AcceptListOfDurationsInSecondsPtr>(shared_library_.get_function_pointer("niFake_AcceptListOfDurationsInSeconds"));
   function_pointers_.BoolArrayOutputFunction = reinterpret_cast<BoolArrayOutputFunctionPtr>(shared_library_.get_function_pointer("niFake_BoolArrayOutputFunction"));
+  function_pointers_.BoolArrayInputFunction = reinterpret_cast<BoolArrayInputFunctionPtr>(shared_library_.get_function_pointer("niFake_BoolArrayInputFunction"));
   function_pointers_.DoubleAllTheNums = reinterpret_cast<DoubleAllTheNumsPtr>(shared_library_.get_function_pointer("niFake_DoubleAllTheNums"));
   function_pointers_.EnumArrayOutputFunction = reinterpret_cast<EnumArrayOutputFunctionPtr>(shared_library_.get_function_pointer("niFake_EnumArrayOutputFunction"));
   function_pointers_.EnumInputFunctionWithDefaults = reinterpret_cast<EnumInputFunctionWithDefaultsPtr>(shared_library_.get_function_pointer("niFake_EnumInputFunctionWithDefaults"));
@@ -118,6 +119,18 @@ ViStatus NiFakeLibrary::BoolArrayOutputFunction(ViSession vi, ViInt32 numberOfEl
   return niFake_BoolArrayOutputFunction(vi, numberOfElements, anArray);
 #else
   return function_pointers_.BoolArrayOutputFunction(vi, numberOfElements, anArray);
+#endif
+}
+
+ViStatus NiFakeLibrary::BoolArrayInputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[])
+{
+  if (!function_pointers_.BoolArrayInputFunction) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_BoolArrayInputFunction.");
+  }
+#if defined(_MSC_VER)
+  return niFake_BoolArrayInputFunction(vi, numberOfElements, anArray);
+#else
+  return function_pointers_.BoolArrayInputFunction(vi, numberOfElements, anArray);
 #endif
 }
 

--- a/generated/nifake/nifake_library.h
+++ b/generated/nifake/nifake_library.h
@@ -21,6 +21,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus Abort(ViSession vi);
   ViStatus AcceptListOfDurationsInSeconds(ViSession vi, ViInt32 count, ViReal64 delays[]);
   ViStatus BoolArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
+  ViStatus BoolArrayInputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
   ViStatus DoubleAllTheNums(ViSession vi, ViInt32 numberCount, ViReal64 numbers[]);
   ViStatus EnumArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViInt16 anArray[]);
   ViStatus EnumInputFunctionWithDefaults(ViSession vi, ViInt16 aTurtle);
@@ -74,6 +75,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using AbortPtr = ViStatus (*)(ViSession vi);
   using AcceptListOfDurationsInSecondsPtr = ViStatus (*)(ViSession vi, ViInt32 count, ViReal64 delays[]);
   using BoolArrayOutputFunctionPtr = ViStatus (*)(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
+  using BoolArrayInputFunctionPtr = ViStatus (*)(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
   using DoubleAllTheNumsPtr = ViStatus (*)(ViSession vi, ViInt32 numberCount, ViReal64 numbers[]);
   using EnumArrayOutputFunctionPtr = ViStatus (*)(ViSession vi, ViInt32 numberOfElements, ViInt16 anArray[]);
   using EnumInputFunctionWithDefaultsPtr = ViStatus (*)(ViSession vi, ViInt16 aTurtle);
@@ -127,6 +129,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     AbortPtr Abort;
     AcceptListOfDurationsInSecondsPtr AcceptListOfDurationsInSeconds;
     BoolArrayOutputFunctionPtr BoolArrayOutputFunction;
+    BoolArrayInputFunctionPtr BoolArrayInputFunction;
     DoubleAllTheNumsPtr DoubleAllTheNums;
     EnumArrayOutputFunctionPtr EnumArrayOutputFunction;
     EnumInputFunctionWithDefaultsPtr EnumInputFunctionWithDefaults;

--- a/generated/nifake/nifake_library_interface.h
+++ b/generated/nifake/nifake_library_interface.h
@@ -18,6 +18,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus Abort(ViSession vi) = 0;
   virtual ViStatus AcceptListOfDurationsInSeconds(ViSession vi, ViInt32 count, ViReal64 delays[]) = 0;
   virtual ViStatus BoolArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]) = 0;
+  virtual ViStatus BoolArrayInputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]) = 0;
   virtual ViStatus DoubleAllTheNums(ViSession vi, ViInt32 numberCount, ViReal64 numbers[]) = 0;
   virtual ViStatus EnumArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViInt16 anArray[]) = 0;
   virtual ViStatus EnumInputFunctionWithDefaults(ViSession vi, ViInt16 aTurtle) = 0;

--- a/generated/nifake/nifake_mock_library.h
+++ b/generated/nifake/nifake_mock_library.h
@@ -20,6 +20,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, Abort, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, AcceptListOfDurationsInSeconds, (ViSession vi, ViInt32 count, ViReal64 delays[]), (override));
   MOCK_METHOD(ViStatus, BoolArrayOutputFunction, (ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]), (override));
+  MOCK_METHOD(ViStatus, BoolArrayInputFunction, (ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]), (override));
   MOCK_METHOD(ViStatus, DoubleAllTheNums, (ViSession vi, ViInt32 numberCount, ViReal64 numbers[]), (override));
   MOCK_METHOD(ViStatus, EnumArrayOutputFunction, (ViSession vi, ViInt32 numberOfElements, ViInt16 anArray[]), (override));
   MOCK_METHOD(ViStatus, EnumInputFunctionWithDefaults, (ViSession vi, ViInt16 aTurtle), (override));

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -110,6 +110,30 @@ namespace nifake_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::BoolArrayInputFunction(::grpc::ServerContext* context, const BoolArrayInputFunctionRequest* request, BoolArrayInputFunctionResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViInt32 number_of_elements = request->number_of_elements();
+      auto an_array_request = request->an_array();
+      std::vector<ViBoolean> an_array;
+      std::transform(an_array_request.begin(), an_array_request.end(), std::back_inserter(an_array), [](auto x) { return (ViBoolean)x; });
+
+      auto status = library_->BoolArrayInputFunction(vi, number_of_elements, an_array.data());
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::DoubleAllTheNums(::grpc::ServerContext* context, const DoubleAllTheNumsRequest* request, DoubleAllTheNumsResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -27,6 +27,7 @@ public:
   ::grpc::Status Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response) override;
   ::grpc::Status AcceptListOfDurationsInSeconds(::grpc::ServerContext* context, const AcceptListOfDurationsInSecondsRequest* request, AcceptListOfDurationsInSecondsResponse* response) override;
   ::grpc::Status BoolArrayOutputFunction(::grpc::ServerContext* context, const BoolArrayOutputFunctionRequest* request, BoolArrayOutputFunctionResponse* response) override;
+  ::grpc::Status BoolArrayInputFunction(::grpc::ServerContext* context, const BoolArrayInputFunctionRequest* request, BoolArrayInputFunctionResponse* response) override;
   ::grpc::Status DoubleAllTheNums(::grpc::ServerContext* context, const DoubleAllTheNumsRequest* request, DoubleAllTheNumsResponse* response) override;
   ::grpc::Status EnumArrayOutputFunction(::grpc::ServerContext* context, const EnumArrayOutputFunctionRequest* request, EnumArrayOutputFunctionResponse* response) override;
   ::grpc::Status EnumInputFunctionWithDefaults(::grpc::ServerContext* context, const EnumInputFunctionWithDefaultsRequest* request, EnumInputFunctionWithDefaultsResponse* response) override;

--- a/source/codegen/metadata/nifake/CHANGES.md
+++ b/source/codegen/metadata/nifake/CHANGES.md
@@ -1,0 +1,7 @@
+# Changes in metadata from the nimi-python metadata
+
+## functions.py
+
+The following APIs were newly added :
+- BoolArrayInputFunction
+	- This function allows testing of ViBoolean[] input parameter

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -94,6 +94,43 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'BoolArrayInputFunction': {
+        'codegen_method': 'public',
+        'documentation': {
+            'description': 'This function accepts an array of booleans.'
+        },
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies a particular instrument session. You obtain the **vi** parameter from niFake_InitWithOptions.'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Number of elements in the array.'
+                },
+                'name': 'numberOfElements',
+                'type': 'ViInt32'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Input boolean array'
+                },
+                'name': 'anArray',
+                'size': {
+                    'mechanism': 'passed-in',
+                    'value': 'numberOfElements'
+                },
+                'type': 'ViBoolean[]'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'DoubleAllTheNums': {
         'documentation': {
             'description': 'Test for buffer with converter'

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -525,6 +525,33 @@ TEST(NiFakeServiceTests, NiFakeService_BoolArrayOutputFunction_CallsBoolArrayOut
   EXPECT_THAT(response.an_array(), ElementsAreArray(expected_response_booleans, number_of_elements));
 }
 
+TEST(NiFakeServiceTests, NiFakeService_BoolArrayInputFunction_CallsBoolArrayInputFunction)
+{
+  nidevice_grpc::SessionRepository session_repository;
+  std::uint32_t session_id = create_session(session_repository, kTestViSession);
+  NiFakeMockLibrary library;
+  nifake_grpc::NiFakeService service(&library, &session_repository);
+  ViInt32 number_of_elements = 3;
+  ViBoolean expected_array[] = { VI_FALSE, VI_TRUE, VI_TRUE };
+  EXPECT_CALL(library, BoolArrayInputFunction(kTestViSession, number_of_elements, _))
+    .With(Args<2, 1>(ElementsAreArray(expected_array)))
+    .WillOnce(Return(kDriverSuccess));
+
+  ::grpc::ServerContext context;
+  nifake_grpc::BoolArrayInputFunctionRequest request;
+  request.mutable_vi()->set_id(session_id);
+  request.set_number_of_elements(number_of_elements);
+  bool input_array[] = { false, true, true };
+  for (bool item : input_array) {
+    request.add_an_array(item);
+  }
+  nifake_grpc::BoolArrayInputFunctionResponse response;
+  ::grpc::Status status = service.BoolArrayInputFunction(&context, &request, &response);
+
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(kDriverSuccess, response.status());
+}
+
 TEST(NiFakeServiceTests, NiFakeService_DoubleAllTheNums_CallsDoubleAllTheNums)
 {
   nidevice_grpc::SessionRepository session_repository;


### PR DESCRIPTION
### What does this Pull Request accomplish?

PR #20 added mako support for ViBoolean[] types for function parameters. Test for "out" parameter type was submitted with that change. This PR adds new function in ni-fake metadata with ViBoolean[] input parameter and adds corresponding unit test. CHANGES.md is updated as well.

### Why should this Pull Request be merged?

The unit test will test integrity of new codegen functionality added for ViBoolean[] input parameters.

### What testing has been done?

Executed the unit test locally
