### PR TITLE
[Owners Review] Added 'custom_close' tag to InitExtCal function of DCPower

### DIFF
--- a/generated/nidcpower/nidcpower.proto
+++ b/generated/nidcpower/nidcpower.proto
@@ -367,6 +367,12 @@ enum AutorangeThresholdMode {
   AUTORANGE_THRESHOLD_MODE_NIDCPOWER_VAL_THRESHOLD_MODE_HOLD = 1116;
 }
 
+enum CalibrationCloseAction {
+  CALIBRATION_CLOSE_ACTION_UNSPECIFIED = 0;
+  CALIBRATION_CLOSE_ACTION_NIDCPOWER_VAL_CANCEL = 1001;
+  CALIBRATION_CLOSE_ACTION_NIDCPOWER_VAL_COMMIT = 1002;
+}
+
 enum ComplianceLimitSymmetry {
   option allow_alias = true;
   COMPLIANCE_LIMIT_SYMMETRY_UNSPECIFIED = 0;
@@ -974,7 +980,10 @@ message CloseResponse {
 
 message CloseExtCalRequest {
   nidevice_grpc.Session vi = 1;
-  sint32 action = 2;
+  oneof action_enum {
+    CalibrationCloseAction action = 2;
+    sint32 action_raw = 3;
+  }
 }
 
 message CloseExtCalResponse {

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -1061,7 +1061,19 @@ namespace nidcpower_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 action = request->action();
+      ViInt32 action;
+      switch (request->action_enum_case()) {
+        case nidcpower_grpc::CloseExtCalRequest::ActionEnumCase::kAction:
+          action = (ViInt32)request->action();
+          break;
+        case nidcpower_grpc::CloseExtCalRequest::ActionEnumCase::kActionRaw:
+          action = (ViInt32)request->action_raw();
+          break;
+        case nidcpower_grpc::CloseExtCalRequest::ActionEnumCase::ACTION_ENUM_NOT_SET:
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for action was not specified or out of range");
+          break;
+      }
+
       auto status = library_->CloseExtCal(vi, action);
       response->set_status(status);
       return ::grpc::Status::OK;
@@ -2751,7 +2763,7 @@ namespace nidcpower_grpc {
       };
       uint32_t session_id = 0;
       const std::string& session_name = request->session_name();
-      auto cleanup_lambda = [&] (uint32_t id) { library_->Close(id); };
+      auto cleanup_lambda = [&] (uint32_t id) { library_->CloseExtCal(id, NIDCPOWER_VAL_CANCEL); };
       int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
       if (status == 0) {

--- a/source/codegen/metadata/nidcpower/CHANGES.md
+++ b/source/codegen/metadata/nidcpower/CHANGES.md
@@ -16,7 +16,7 @@ The following function name was capitalised:
 The following functions were tagged with 'init_method': True, to ensure their generated service handler registers the new session with the session_repository:
 - InitializeWithIndependentChannels
 - InitializeWithChannels
-- InitExtCal
+- InitExtCal : Added a 'custom_close' tag to this function, since this API has a corresponding close function called 'CloseExtCal'
 
 The following functions were tagged with their corresponding c_names:
 - reset
@@ -50,3 +50,9 @@ The following attributes were added :
 - NIDCPOWER_ATTRIBUTE_DIGITAL_EDGE_MEASURE_TRIGGER_EDGE
 - NIDCPOWER_ATTRIBUTE_DIGITAL_EDGE_PULSE_TRIGGER_EDGE
 - NIDCPOWER_ATTRIBUTE_DIGITAL_EDGE_SHUTDOWN_TRIGGER_EDGE
+
+## enums.py
+
+The following enums were added :
+- NIDCPOWER_VAL_CANCEL
+- NIDCPOWER_VAL_COMMIT

--- a/source/codegen/metadata/nidcpower/CHANGES.md
+++ b/source/codegen/metadata/nidcpower/CHANGES.md
@@ -16,7 +16,8 @@ The following function name was capitalised:
 The following functions were tagged with 'init_method': True, to ensure their generated service handler registers the new session with the session_repository:
 - InitializeWithIndependentChannels
 - InitializeWithChannels
-- InitExtCal : Added a 'custom_close' tag to this function, since this API has a corresponding close function called 'CloseExtCal'
+- InitExtCal : 
+    - Also added a 'custom_close' tag to this function, since this API has a corresponding close function called 'CloseExtCal'
 
 The following functions were tagged with their corresponding c_names:
 - reset

--- a/source/codegen/metadata/nidcpower/enums.py
+++ b/source/codegen/metadata/nidcpower/enums.py
@@ -126,6 +126,18 @@ enums = {
             }
         ]
     },
+    'CalibrationCloseAction': {
+        'values':[
+            {
+                'name': 'NIDCPOWER_VAL_CANCEL',
+                'value': 1001
+            },
+            {
+                'name': 'NIDCPOWER_VAL_COMMIT',
+                'value': 1002
+            }
+        ]
+    },
     'ComplianceLimitSymmetry': {
         'values': [
             {

--- a/source/codegen/metadata/nidcpower/functions.py
+++ b/source/codegen/metadata/nidcpower/functions.py
@@ -1035,6 +1035,7 @@ functions = {
       {
         'name': 'action',
         'direction': 'in',
+        'enum': 'CalibrationCloseAction',
         'type': 'ViInt32'
       }
     ],
@@ -2488,6 +2489,7 @@ functions = {
   },
   'InitExtCal': {
     'init_method' : True,
+    'custom_close': 'CloseExtCal(id, NIDCPOWER_VAL_CANCEL'),
     'parameters': [
       {
         'name': 'resourceName',

--- a/source/codegen/metadata/nidcpower/functions.py
+++ b/source/codegen/metadata/nidcpower/functions.py
@@ -2489,7 +2489,7 @@ functions = {
   },
   'InitExtCal': {
     'init_method' : True,
-    'custom_close': 'CloseExtCal(id, NIDCPOWER_VAL_CANCEL'),
+    'custom_close': 'CloseExtCal(id, NIDCPOWER_VAL_CANCEL)',
     'parameters': [
       {
         'name': 'resourceName',

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -7,6 +7,7 @@
 <%def name="define_init_method_body(function_name, function_data, parameters)">\
 <%
   config = data['config']
+
   output_parameters = [p for p in parameters if common_helpers.is_output_parameter(p)]
   session_output_param = next((parameter for parameter in output_parameters if parameter['type'] == 'ViSession'), None)
   session_output_var_name = session_output_param['cppName']
@@ -19,7 +20,11 @@ ${initialize_input_params(function_name, parameters)}
       };
       uint32_t session_id = 0;
       const std::string& session_name = request->session_name();
+      %if 'custom_close' in function_data:
+      auto cleanup_lambda = [&] (uint32_t id) { library_->${function_data['custom_close']}; };
+      %else:
       auto cleanup_lambda = [&] (uint32_t id) { library_->${config['close_function']}(id); };
+      %endif
       int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
       if (status == 0) {

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -6,8 +6,7 @@
 ## Generate the core method body for an Init method. This should be what gets included within the try block in the service method.
 <%def name="define_init_method_body(function_name, function_data, parameters)">\
 <%
-  config = data['config']
-
+  config = data['config'] 
   output_parameters = [p for p in parameters if common_helpers.is_output_parameter(p)]
   session_output_param = next((parameter for parameter in output_parameters if parameter['type'] == 'ViSession'), None)
   session_output_var_name = session_output_param['cppName']
@@ -20,11 +19,10 @@ ${initialize_input_params(function_name, parameters)}
       };
       uint32_t session_id = 0;
       const std::string& session_name = request->session_name();
-      %if 'custom_close' in function_data:
-      auto cleanup_lambda = [&] (uint32_t id) { library_->${function_data['custom_close']}; };
-      %else:
-      auto cleanup_lambda = [&] (uint32_t id) { library_->${config['close_function']}(id); };
-      %endif
+<%
+ close_function_call = function_data['custom_close'] if 'custom_close' in function_data else f"{config['close_function']}(id)"
+%>\
+      auto cleanup_lambda = [&] (uint32_t id) { library_->${close_function_call}; };      
       int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
       if (status == 0) {

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -6,7 +6,7 @@
 ## Generate the core method body for an Init method. This should be what gets included within the try block in the service method.
 <%def name="define_init_method_body(function_name, function_data, parameters)">\
 <%
-  config = data['config'] 
+  config = data['config']
   output_parameters = [p for p in parameters if common_helpers.is_output_parameter(p)]
   session_output_param = next((parameter for parameter in output_parameters if parameter['type'] == 'ViSession'), None)
   session_output_var_name = session_output_param['cppName']

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -10,6 +10,7 @@
   output_parameters = [p for p in parameters if common_helpers.is_output_parameter(p)]
   session_output_param = next((parameter for parameter in output_parameters if parameter['type'] == 'ViSession'), None)
   session_output_var_name = session_output_param['cppName']
+  close_function_call = function_data['custom_close'] if 'custom_close' in function_data else f"{config['close_function']}(id)"
 %>\
 ${initialize_input_params(function_name, parameters)}
       auto init_lambda = [&] () -> std::tuple<int, uint32_t> {
@@ -19,10 +20,7 @@ ${initialize_input_params(function_name, parameters)}
       };
       uint32_t session_id = 0;
       const std::string& session_name = request->session_name();
-<%
- close_function_call = function_data['custom_close'] if 'custom_close' in function_data else f"{config['close_function']}(id)"
-%>\
-      auto cleanup_lambda = [&] (uint32_t id) { library_->${close_function_call}; };      
+      auto cleanup_lambda = [&] (uint32_t id) { library_->${close_function_call}; };
       int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
       if (status == 0) {


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Added 2 enums for CloseExtCal in enums.py
- Added custom_close tag for InitExtCal in functions.py
- Added enum name for CloseExtCal in functions.py
- Modified Mako File to handle it
- Recorded modifications in changes.md file

NOTE : The changes made in the mako file are same as that made in #33 for DMM. We will take care of it while merging both the feature branches in main.

### Why should this Pull Request be merged?

The cleanup lambda for InitExtClose can now be autogenerated to use CloseExtCal.

### What testing has been done?

Successfully auto-generate InitExtCal and CloseExtCal in service.cpp file.
