### PR TITLE
[Owner Review] Added Powerline Frequency enum to DCPower

### DIFF
--- a/generated/nidcpower/nidcpower.proto
+++ b/generated/nidcpower/nidcpower.proto
@@ -374,10 +374,10 @@ enum ComplianceLimitSymmetry {
   COMPLIANCE_LIMIT_SYMMETRY_NIDCPOWER_VAL_ASYMMETRIC = 1;
 }
 
-enum PowerLineFrequences {
-  POWER_LINE_FREQUENCES_UNSPECIFIED = 0;
-  POWER_LINE_FREQUENCES_NIDCPOWER_VAL_50_HERTZ = 50;
-  POWER_LINE_FREQUENCES_NIDCPOWER_VAL_60_HERTZ = 60;
+enum PowerLineFrequencies {
+  POWER_LINE_FREQUENCIES_UNSPECIFIED = 0;
+  POWER_LINE_FREQUENCIES_NIDCPOWER_VAL_50_HERTZ = 50;
+  POWER_LINE_FREQUENCIES_NIDCPOWER_VAL_60_HERTZ = 60;
 }
 
 enum DCNoiseRejection {
@@ -1146,7 +1146,7 @@ message ConfigureOutputResistanceResponse {
 message ConfigurePowerLineFrequencyRequest {
   nidevice_grpc.Session vi = 1;
   oneof powerline_frequency_enum {
-    PowerLineFrequences powerline_frequency = 2;
+    PowerLineFrequencies powerline_frequency = 2;
     double powerline_frequency_raw = 3;
   }
 }

--- a/generated/nidcpower/nidcpower.proto
+++ b/generated/nidcpower/nidcpower.proto
@@ -374,6 +374,12 @@ enum ComplianceLimitSymmetry {
   COMPLIANCE_LIMIT_SYMMETRY_NIDCPOWER_VAL_ASYMMETRIC = 1;
 }
 
+enum PowerLineFrequences {
+  POWER_LINE_FREQUENCES_UNSPECIFIED = 0;
+  POWER_LINE_FREQUENCES_NIDCPOWER_VAL_50_HERTZ = 50;
+  POWER_LINE_FREQUENCES_NIDCPOWER_VAL_60_HERTZ = 60;
+}
+
 enum DCNoiseRejection {
   D_C_NOISE_REJECTION_UNSPECIFIED = 0;
   D_C_NOISE_REJECTION_NIDCPOWER_VAL_DC_NOISE_REJECTION_SECOND_ORDER = 1043;
@@ -1139,7 +1145,10 @@ message ConfigureOutputResistanceResponse {
 
 message ConfigurePowerLineFrequencyRequest {
   nidevice_grpc.Session vi = 1;
-  double powerline_frequency = 2;
+  oneof powerline_frequency_enum {
+    PowerLineFrequences powerline_frequency = 2;
+    double powerline_frequency_raw = 3;
+  }
 }
 
 message ConfigurePowerLineFrequencyResponse {

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -1420,7 +1420,19 @@ namespace nidcpower_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViReal64 powerline_frequency = request->powerline_frequency();
+      ViReal64 powerline_frequency;
+      switch (request->powerline_frequency_enum_case()) {
+        case nidcpower_grpc::ConfigurePowerLineFrequencyRequest::PowerlineFrequencyEnumCase::kPowerlineFrequency:
+          powerline_frequency = (ViReal64)request->powerline_frequency();
+          break;
+        case nidcpower_grpc::ConfigurePowerLineFrequencyRequest::PowerlineFrequencyEnumCase::kPowerlineFrequencyRaw:
+          powerline_frequency = (ViReal64)request->powerline_frequency_raw();
+          break;
+        case nidcpower_grpc::ConfigurePowerLineFrequencyRequest::PowerlineFrequencyEnumCase::POWERLINE_FREQUENCY_ENUM_NOT_SET:
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for powerline_frequency was not specified or out of range");
+          break;
+      }
+
       auto status = library_->ConfigurePowerLineFrequency(vi, powerline_frequency);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/source/codegen/metadata/nidcpower/CHANGES.md
+++ b/source/codegen/metadata/nidcpower/CHANGES.md
@@ -62,6 +62,7 @@ The following function was tagged with `'codegen_method': 'private'`, because th
 - `internalReference` parameter in `ConnectInternalReference`
 - `trigger` parameter in `SendSoftwareEdgeTrigger`
 - `eventId` parameter in `WaitForEvent`
+- `powerlineFrequency` parameter in `ConfigurePowerLineFrequency`
 
 ## attributes.py
 
@@ -84,6 +85,7 @@ The following attributes were added :
 
 `enum` tag was added to following attributes:
 - NIDCPOWER_ATTRIBUTE_VOLTAGE_LEVEL_AUTORANGE
+- NIDCPOWER_ATTRIBUTE_POWER_LINE_FREQUENCY
 
 ## enums.py
 
@@ -91,3 +93,4 @@ Following enums were defined :
 - InternalReference
 - NIDCPOWER_VAL_CANCEL
 - NIDCPOWER_VAL_COMMIT
+- PowerLineFrequencies

--- a/source/codegen/metadata/nidcpower/attributes.py
+++ b/source/codegen/metadata/nidcpower/attributes.py
@@ -293,7 +293,7 @@ attributes = {
         'access': 'read-write',
         'channel_based': True,
         'name': 'POWER_LINE_FREQUENCY',
-        'enum': 'PowerLineFrequences',
+        'enum': 'PowerLineFrequencies',
         'resettable': False,
         'type': 'ViReal64'
     },

--- a/source/codegen/metadata/nidcpower/attributes.py
+++ b/source/codegen/metadata/nidcpower/attributes.py
@@ -293,6 +293,7 @@ attributes = {
         'access': 'read-write',
         'channel_based': True,
         'name': 'POWER_LINE_FREQUENCY',
+        'enum': 'PowerLineFrequences',
         'resettable': False,
         'type': 'ViReal64'
     },

--- a/source/codegen/metadata/nidcpower/enums.py
+++ b/source/codegen/metadata/nidcpower/enums.py
@@ -144,6 +144,18 @@ enums = {
             }
         ]
     },
+    'PowerLineFrequences': {
+        'values': [
+            {
+                'name': 'NIDCPOWER_VAL_50_HERTZ',
+                'value': 50
+            },
+            {
+                'name': 'NIDCPOWER_VAL_60_HERTZ',
+                'value': 60
+            }
+        ]
+    },
     'CurrentLimitBehavior': {
         'values': [
             {

--- a/source/codegen/metadata/nidcpower/enums.py
+++ b/source/codegen/metadata/nidcpower/enums.py
@@ -144,7 +144,7 @@ enums = {
             }
         ]
     },
-    'PowerLineFrequences': {
+    'PowerLineFrequencies': {
         'values': [
             {
                 'name': 'NIDCPOWER_VAL_50_HERTZ',

--- a/source/codegen/metadata/nidcpower/functions.py
+++ b/source/codegen/metadata/nidcpower/functions.py
@@ -1352,7 +1352,7 @@ functions = {
       {
         'name': 'powerlineFrequency',
         'direction': 'in',
-        'enum': 'PowerLineFrequences',
+        'enum': 'PowerLineFrequencies',
         'type': 'ViReal64'
       }
     ],

--- a/source/codegen/metadata/nidcpower/functions.py
+++ b/source/codegen/metadata/nidcpower/functions.py
@@ -1352,6 +1352,7 @@ functions = {
       {
         'name': 'powerlineFrequency',
         'direction': 'in',
+        'enum': 'PowerLineFrequences',
         'type': 'ViReal64'
       }
     ],


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds metadata `PowerLineFrequencies` enum to ni-dcpower and generates the enum

### Why should this Pull Request be merged?

`ConfigurePowerLines` API and `NIDCPOWER_ATTRIBUTE_POWER_LINE_FREQUENCY` makes use of the enum in case of C API(in form of defined constant), so similarly enum support for them added for grpc API. 

### What testing has been done?

The built was run successfully and the enum got generated
