### PR TITLE
[Owner Review] DMM example updates (option string, UNIMPLEMENTED, retain data upto 2 decimals)

### DIFF
--- a/examples/nidmm/continuous-acquire-graph-multiple-points.py
+++ b/examples/nidmm/continuous-acquire-graph-multiple-points.py
@@ -29,6 +29,7 @@ import nidmm_pb2_grpc as grpc_nidmm
 import session_pb2 as session_types
 import session_pb2_grpc as grpc_session
 import matplotlib.pyplot as plt
+import numpy as np
 import keyword
 
 server_address = "localhost"
@@ -170,7 +171,10 @@ try:
                 ))
                 CheckForError(vi, fetch_multipoints_response.status)
                 num_pts_read = fetch_multipoints_response.actual_number_of_points
-                measurements = fetch_multipoints_response.reading_array
+                measurements = np.array(fetch_multipoints_response.reading_array)
+                
+                # retain data to 2 decimals
+                measurements = np.floor(measurements * 100) / 100.0
 
                 # Update the plot with the new measurements
                 plt.plot(measurements)

--- a/examples/nidmm/continuous-acquire-graph-multiple-points.py
+++ b/examples/nidmm/continuous-acquire-graph-multiple-points.py
@@ -204,4 +204,6 @@ except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
         error_message = f"Failed to connect to server on {server_address}"
+    elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
+        error_message = f"Function not implemented"
     print(f"{error_message}") 

--- a/examples/nidmm/continuous-acquire-graph-multiple-points.py
+++ b/examples/nidmm/continuous-acquire-graph-multiple-points.py
@@ -193,12 +193,6 @@ try:
     average = sum_measurements/num_measurements
     print(f'Average = {average}')
 
-    # Close NI-DMM session
-    close_session_response = nidmm_client.Close(nidmm_types.CloseRequest(
-        vi = vi
-    ))
-    CheckForError(vi, close_session_response.status)
-
 # If NI-DMM API throws an exception, print the error message  
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
@@ -207,3 +201,10 @@ except grpc.RpcError as rpc_error:
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = f"Function not implemented"
     print(f"{error_message}") 
+finally:
+    if('vi' in vars() and vi.id != 0):
+        # Close NI-DMM session
+        close_session_response = nidmm_client.Close(nidmm_types.CloseRequest(
+            vi = vi
+        ))
+        CheckForError(vi, close_session_response.status)

--- a/examples/nidmm/continuous-acquire-graph-multiple-points.py
+++ b/examples/nidmm/continuous-acquire-graph-multiple-points.py
@@ -203,7 +203,9 @@ except grpc.RpcError as rpc_error:
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
         error_message = f"Failed to connect to server on {server_address}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = f"Function not implemented"
+        error_message = "The operation is not implemented or is not supported/enabled in this service"
+    elif rpc_error.code() == grpc.StatusCode.NOT_FOUND:
+        error_message = "The requested function/entity was not found"
     print(f"{error_message}") 
 finally:
     if('vi' in vars() and vi.id != 0):

--- a/examples/nidmm/continuous-acquire-graph-multiple-points.py
+++ b/examples/nidmm/continuous-acquire-graph-multiple-points.py
@@ -37,7 +37,7 @@ session_name = "NI-DMM-Session"
 
 # Resource name and options for a simulated 4065 client. Change them according to the NI-DMM model.
 resource = "SimulatedDMM"
-options = "Simulate=1, DriverSetup=Model:4065; BoardType:PCI"
+options = "Simulate=1, DriverSetup=Model:4080; BoardType:PXIe"
 
 # parameters
 MAXPTSTOREAD        = 1000

--- a/source/tests/system/nidmm_driver_api_tests.cpp
+++ b/source/tests/system/nidmm_driver_api_tests.cpp
@@ -63,7 +63,7 @@ class NiDmmDriverApiTest : public ::testing::Test {
           ::grpc::ClientContext context;
           dmm::InitWithOptionsRequest request;
           request.set_resource_name("SimulatedDMM");
-          request.set_option_string("Simulate=1, DriverSetup=Model:4071; BoardType:PXI");
+          request.set_option_string("Simulate=1, DriverSetup=Model:4080; BoardType:PXIe");
           request.set_session_name("");
           request.set_reset_device(false);
           request.set_id_query(false);

--- a/source/tests/system/nidmm_session_tests.cpp
+++ b/source/tests/system/nidmm_session_tests.cpp
@@ -12,7 +12,7 @@ namespace dmm = nidmm_grpc;
 const int kViErrorRsrcNFound = -1074118656;
 const char* kViErrorResourceNotFoundMessage = "Device was not recognized. The device is not supported with this driver or version.";
 const char* kResourceName = "FakeDevice";
-const char* kOptionsString = "Simulate=1, DriverSetup=Model:4065; BoardType:PCI";
+const char* kOptionsString = "Simulate=1, DriverSetup=Model:4080; BoardType:PXIe";
 const char* kSessionName = "SessionName";
 const char* kInvalidRsrc = "";
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Change the option string in the example to use PXIe-4080 because only 408x models can be simulated in linux. Also, added handling of error when the server is not build with DMM APIs but the example is called onto the server.
Changed the example to keep only 2 decimal places in the measurements

### Why should this Pull Request be merged?

Changing the string allows the example to run on linux. Adding the error handling gives user information why example not working, as with the original error handling, empty string gets printed because the details field of the error remains empty for this exception case
The data was having many decimal places because of which the plot was displaying it in e^-n format. So it is not changed to have only 2 decimals

### What testing has been done?

The example is tested on the local machine.