### PR TITLE
[Peer Review] Retain measurement data in DMM example to 2 decimal places

### DIFF
--- a/examples/nidmm/continuous-acquire-graph-multiple-points.py
+++ b/examples/nidmm/continuous-acquire-graph-multiple-points.py
@@ -30,6 +30,7 @@ import session_pb2 as session_types
 import session_pb2_grpc as grpc_session
 import matplotlib.pyplot as plt
 import keyword
+import numpy as np
 
 server_address = "localhost"
 server_port = "31763"
@@ -170,7 +171,10 @@ try:
                 ))
                 CheckForError(vi, fetch_multipoints_response.status)
                 num_pts_read = fetch_multipoints_response.actual_number_of_points
-                measurements = fetch_multipoints_response.reading_array
+                measurements = np.array(fetch_multipoints_response.reading_array)
+
+                # retain data to 2 decimals
+                measurements = np.floor(measurements * 100) / 100.0
 
                 # Update the plot with the new measurements
                 plt.plot(measurements)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Changed the example to keep only 2 decimal places in the measurements

### Why should this Pull Request be merged?

The data was having many decimal places because of which the plot was displaying it in e^-n format. So it is not changed to have only 2 decimals

### What testing has been done?

The example tested on local machine
