### PR TITLE
[Owner Review] Added more missing enums to DMM

### DIFF
--- a/examples/nidmm/continuous-acquire-graph-multiple-points.py
+++ b/examples/nidmm/continuous-acquire-graph-multiple-points.py
@@ -36,7 +36,7 @@ server_address = "localhost"
 server_port = "31763"
 session_name = "NI-DMM-Session"
 
-# Resource name and options for a simulated 4065 client. Change them according to the NI-DMM model.
+# Resource name and options for a simulated 4080 client. Change them according to the NI-DMM model.
 resource = "SimulatedDMM"
 options = "Simulate=1, DriverSetup=Model:4080; BoardType:PXIe"
 

--- a/examples/nidmm/continuous-acquire-graph-multiple-points.py
+++ b/examples/nidmm/continuous-acquire-graph-multiple-points.py
@@ -100,10 +100,10 @@ try:
     # Configure a multipoint acquisition
     config_multipoint_response = nidmm_client.ConfigureMultiPoint(nidmm_types.ConfigureMultiPointRequest(
         vi = vi,
-        trigger_count = 1,
-        sample_count = 0,
+        trigger_count_raw = 1,
+        sample_count = nidmm_types.SampleCount.SAMPLE_COUNT_NIDMM_VAL_SAMPLE_COUNT_INFINITE,
         sample_trigger = nidmm_types.SampleTrigger.SAMPLE_TRIGGER_NIDMM_VAL_IMMEDIATE,
-        sample_interval = 0.0
+        sample_interval_raw = 0.0
     ))
     CheckForError(vi, config_multipoint_response.status)
 

--- a/generated/nidmm/nidmm.proto
+++ b/generated/nidmm/nidmm.proto
@@ -128,7 +128,7 @@ enum NiDmmAttributes {
   NIDMM_ATTRIBUTE_QUERY_INSTRUMENT_STATUS = 1050003;
   NIDMM_ATTRIBUTE_CACHE = 1050004;
   NIDMM_ATTRIBUTE_SIMULATE = 1050005;
-  NIDMM_ATTRIBUTE_READ_COERCIONS = 1050006;
+  NIDMM_ATTRIBUTE_RECORD_COERCIONS = 1050006;
   NIDMM_ATTRIBUTE_DRIVER_SETUP = 1050007;
   NIDMM_ATTRIBUTE_INTERCHANGE_CHECK = 1050021;
   NIDMM_ATTRIBUTE_CHANNEL_COUNT = 1050203;
@@ -166,7 +166,7 @@ enum NiDmmAttributes {
   NIDMM_ATTRIBUTE_NUMBER_OF_AVERAGES = 1150032;
   NIDMM_ATTRIBUTE_LATENCY = 1150034;
   NIDMM_ATTRIBUTE_BUFFER_SIZE = 1150037;
-  NIDMM_ATTRIBUTE_FREQ_VOLTAGE_AUTO_RANGE = 1150044;
+  NIDMM_ATTRIBUTE_FREQ_VOLTAGE_AUTO_RANGE_VALUE = 1150044;
   NIDMM_ATTRIBUTE_CABLE_COMP_TYPE = 1150045;
   NIDMM_ATTRIBUTE_SHORT_CABLE_COMP_REACTANCE = 1150046;
   NIDMM_ATTRIBUTE_SHORT_CABLE_COMP_RESISTANCE = 1150047;
@@ -325,6 +325,12 @@ enum DcNoiseRejection {
   DC_NOISE_REJECTION_NIDMM_VAL_DCNR_HIGH_ORDER = 2;
 }
 
+enum FrequencyVoltageRange {
+  FREQUENCY_VOLTAGE_RANGE_UNSPECIFIED = 0;
+  FREQUENCY_VOLTAGE_RANGE_NIDMM_VAL_AUTO_RANGE_ON = -1;
+  FREQUENCY_VOLTAGE_RANGE_NIDMM_VAL_AUTO_RANGE_OFF = -2;
+}
+
 enum Function {
   FUNCTION_UNSPECIFIED = 0;
   FUNCTION_NIDMM_VAL_DC_VOLTS = 1;
@@ -440,6 +446,17 @@ enum RtdType {
   RTD_TYPE_NIDMM_VAL_TEMP_RTD_PT3928 = 6;
 }
 
+enum SampleCount {
+  option allow_alias = true;
+  SAMPLE_COUNT_UNSPECIFIED = 0;
+  SAMPLE_COUNT_NIDMM_VAL_SAMPLE_COUNT_INFINITE = 0;
+}
+
+enum SampleInterval {
+  SAMPLE_INTERVAL_UNSPECIFIED = 0;
+  SAMPLE_INTERVAL_NIDMM_VAL_AUTO_DELAY = -1;
+}
+
 enum SampleTrigSlope {
   option allow_alias = true;
   SAMPLE_TRIG_SLOPE_UNSPECIFIED = 0;
@@ -497,12 +514,23 @@ enum ThermocoupleType {
   THERMOCOUPLE_TYPE_NIDMM_VAL_TEMP_TC_T = 11;
 }
 
+enum TimeLimit {
+  TIME_LIMIT_UNSPECIFIED = 0;
+  TIME_LIMIT_NIDMM_VAL_TIME_LIMIT_AUTO = -1;
+}
+
 enum TransducerType {
   TRANSDUCER_TYPE_UNSPECIFIED = 0;
   TRANSDUCER_TYPE_NIDMM_VAL_THERMOCOUPLE = 1;
   TRANSDUCER_TYPE_NIDMM_VAL_THERMISTOR = 2;
   TRANSDUCER_TYPE_NIDMM_VAL_2_WIRE_RTD = 3;
   TRANSDUCER_TYPE_NIDMM_VAL_4_WIRE_RTD = 4;
+}
+
+enum TriggerCount {
+  option allow_alias = true;
+  TRIGGER_COUNT_UNSPECIFIED = 0;
+  TRIGGER_COUNT_NIDMM_VAL_TRIG_COUNT_INFINITE = 0;
 }
 
 enum TriggerDelays {
@@ -782,7 +810,10 @@ message ConfigureFixedRefJunctionResponse {
 
 message ConfigureFrequencyVoltageRangeRequest {
   nidevice_grpc.Session vi = 1;
-  double voltage_range = 2;
+  oneof voltage_range_enum {
+    FrequencyVoltageRange voltage_range = 2;
+    double voltage_range_raw = 3;
+  }
 }
 
 message ConfigureFrequencyVoltageRangeResponse {
@@ -837,13 +868,22 @@ message ConfigureMeasurementDigitsResponse {
 
 message ConfigureMultiPointRequest {
   nidevice_grpc.Session vi = 1;
-  sint32 trigger_count = 2;
-  sint32 sample_count = 3;
-  oneof sample_trigger_enum {
-    SampleTrigger sample_trigger = 4;
-    sint32 sample_trigger_raw = 5;
+  oneof trigger_count_enum {
+    TriggerCount trigger_count = 2;
+    sint32 trigger_count_raw = 3;
   }
-  double sample_interval = 6;
+  oneof sample_count_enum {
+    SampleCount sample_count = 4;
+    sint32 sample_count_raw = 5;
+  }
+  oneof sample_trigger_enum {
+    SampleTrigger sample_trigger = 6;
+    sint32 sample_trigger_raw = 7;
+  }
+  oneof sample_interval_enum {
+    SampleInterval sample_interval = 8;
+    double sample_interval_raw = 9;
+  }
 }
 
 message ConfigureMultiPointResponse {
@@ -1067,7 +1107,10 @@ message ExportAttributeConfigurationFileResponse {
 
 message FetchRequest {
   nidevice_grpc.Session vi = 1;
-  sint32 maximum_time = 2;
+  oneof maximum_time_enum {
+    TimeLimit maximum_time = 2;
+    sint32 maximum_time_raw = 3;
+  }
 }
 
 message FetchResponse {
@@ -1077,8 +1120,11 @@ message FetchResponse {
 
 message FetchMultiPointRequest {
   nidevice_grpc.Session vi = 1;
-  sint32 maximum_time = 2;
-  sint32 array_size = 3;
+  oneof maximum_time_enum {
+    TimeLimit maximum_time = 2;
+    sint32 maximum_time_raw = 3;
+  }
+  sint32 array_size = 4;
 }
 
 message FetchMultiPointResponse {
@@ -1089,8 +1135,11 @@ message FetchMultiPointResponse {
 
 message FetchWaveformRequest {
   nidevice_grpc.Session vi = 1;
-  sint32 maximum_time = 2;
-  sint32 array_size = 3;
+  oneof maximum_time_enum {
+    TimeLimit maximum_time = 2;
+    sint32 maximum_time_raw = 3;
+  }
+  sint32 array_size = 4;
 }
 
 message FetchWaveformResponse {
@@ -1443,7 +1492,10 @@ message PerformShortCableCompResponse {
 
 message ReadRequest {
   nidevice_grpc.Session vi = 1;
-  sint32 maximum_time = 2;
+  oneof maximum_time_enum {
+    TimeLimit maximum_time = 2;
+    sint32 maximum_time_raw = 3;
+  }
 }
 
 message ReadResponse {
@@ -1453,8 +1505,11 @@ message ReadResponse {
 
 message ReadMultiPointRequest {
   nidevice_grpc.Session vi = 1;
-  sint32 maximum_time = 2;
-  sint32 array_size = 3;
+  oneof maximum_time_enum {
+    TimeLimit maximum_time = 2;
+    sint32 maximum_time_raw = 3;
+  }
+  sint32 array_size = 4;
 }
 
 message ReadMultiPointResponse {
@@ -1476,8 +1531,11 @@ message ReadStatusResponse {
 
 message ReadWaveformRequest {
   nidevice_grpc.Session vi = 1;
-  sint32 maximum_time = 2;
-  sint32 array_size = 3;
+  oneof maximum_time_enum {
+    TimeLimit maximum_time = 2;
+    sint32 maximum_time_raw = 3;
+  }
+  sint32 array_size = 4;
 }
 
 message ReadWaveformResponse {

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -558,7 +558,19 @@ namespace nidmm_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViReal64 voltage_range = request->voltage_range();
+      ViReal64 voltage_range;
+      switch (request->voltage_range_enum_case()) {
+        case nidmm_grpc::ConfigureFrequencyVoltageRangeRequest::VoltageRangeEnumCase::kVoltageRange:
+          voltage_range = (ViReal64)request->voltage_range();
+          break;
+        case nidmm_grpc::ConfigureFrequencyVoltageRangeRequest::VoltageRangeEnumCase::kVoltageRangeRaw:
+          voltage_range = (ViReal64)request->voltage_range_raw();
+          break;
+        case nidmm_grpc::ConfigureFrequencyVoltageRangeRequest::VoltageRangeEnumCase::VOLTAGE_RANGE_ENUM_NOT_SET:
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for voltage_range was not specified or out of range");
+          break;
+      }
+
       auto status = library_->ConfigureFrequencyVoltageRange(vi, voltage_range);
       response->set_status(status);
       return ::grpc::Status::OK;
@@ -686,8 +698,32 @@ namespace nidmm_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 trigger_count = request->trigger_count();
-      ViInt32 sample_count = request->sample_count();
+      ViInt32 trigger_count;
+      switch (request->trigger_count_enum_case()) {
+        case nidmm_grpc::ConfigureMultiPointRequest::TriggerCountEnumCase::kTriggerCount:
+          trigger_count = (ViInt32)request->trigger_count();
+          break;
+        case nidmm_grpc::ConfigureMultiPointRequest::TriggerCountEnumCase::kTriggerCountRaw:
+          trigger_count = (ViInt32)request->trigger_count_raw();
+          break;
+        case nidmm_grpc::ConfigureMultiPointRequest::TriggerCountEnumCase::TRIGGER_COUNT_ENUM_NOT_SET:
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for trigger_count was not specified or out of range");
+          break;
+      }
+
+      ViInt32 sample_count;
+      switch (request->sample_count_enum_case()) {
+        case nidmm_grpc::ConfigureMultiPointRequest::SampleCountEnumCase::kSampleCount:
+          sample_count = (ViInt32)request->sample_count();
+          break;
+        case nidmm_grpc::ConfigureMultiPointRequest::SampleCountEnumCase::kSampleCountRaw:
+          sample_count = (ViInt32)request->sample_count_raw();
+          break;
+        case nidmm_grpc::ConfigureMultiPointRequest::SampleCountEnumCase::SAMPLE_COUNT_ENUM_NOT_SET:
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for sample_count was not specified or out of range");
+          break;
+      }
+
       ViInt32 sample_trigger;
       switch (request->sample_trigger_enum_case()) {
         case nidmm_grpc::ConfigureMultiPointRequest::SampleTriggerEnumCase::kSampleTrigger:
@@ -701,7 +737,19 @@ namespace nidmm_grpc {
           break;
       }
 
-      ViReal64 sample_interval = request->sample_interval();
+      ViReal64 sample_interval;
+      switch (request->sample_interval_enum_case()) {
+        case nidmm_grpc::ConfigureMultiPointRequest::SampleIntervalEnumCase::kSampleInterval:
+          sample_interval = (ViReal64)request->sample_interval();
+          break;
+        case nidmm_grpc::ConfigureMultiPointRequest::SampleIntervalEnumCase::kSampleIntervalRaw:
+          sample_interval = (ViReal64)request->sample_interval_raw();
+          break;
+        case nidmm_grpc::ConfigureMultiPointRequest::SampleIntervalEnumCase::SAMPLE_INTERVAL_ENUM_NOT_SET:
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for sample_interval was not specified or out of range");
+          break;
+      }
+
       auto status = library_->ConfigureMultiPoint(vi, trigger_count, sample_count, sample_trigger, sample_interval);
       response->set_status(status);
       return ::grpc::Status::OK;
@@ -1255,7 +1303,19 @@ namespace nidmm_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 maximum_time = request->maximum_time();
+      ViInt32 maximum_time;
+      switch (request->maximum_time_enum_case()) {
+        case nidmm_grpc::FetchRequest::MaximumTimeEnumCase::kMaximumTime:
+          maximum_time = (ViInt32)request->maximum_time();
+          break;
+        case nidmm_grpc::FetchRequest::MaximumTimeEnumCase::kMaximumTimeRaw:
+          maximum_time = (ViInt32)request->maximum_time_raw();
+          break;
+        case nidmm_grpc::FetchRequest::MaximumTimeEnumCase::MAXIMUM_TIME_ENUM_NOT_SET:
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for maximum_time was not specified or out of range");
+          break;
+      }
+
       ViReal64 reading {};
       auto status = library_->Fetch(vi, maximum_time, &reading);
       response->set_status(status);
@@ -1279,7 +1339,19 @@ namespace nidmm_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 maximum_time = request->maximum_time();
+      ViInt32 maximum_time;
+      switch (request->maximum_time_enum_case()) {
+        case nidmm_grpc::FetchMultiPointRequest::MaximumTimeEnumCase::kMaximumTime:
+          maximum_time = (ViInt32)request->maximum_time();
+          break;
+        case nidmm_grpc::FetchMultiPointRequest::MaximumTimeEnumCase::kMaximumTimeRaw:
+          maximum_time = (ViInt32)request->maximum_time_raw();
+          break;
+        case nidmm_grpc::FetchMultiPointRequest::MaximumTimeEnumCase::MAXIMUM_TIME_ENUM_NOT_SET:
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for maximum_time was not specified or out of range");
+          break;
+      }
+
       ViInt32 array_size = request->array_size();
       response->mutable_reading_array()->Resize(array_size, 0);
       ViReal64* reading_array = response->mutable_reading_array()->mutable_data();
@@ -1306,7 +1378,19 @@ namespace nidmm_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 maximum_time = request->maximum_time();
+      ViInt32 maximum_time;
+      switch (request->maximum_time_enum_case()) {
+        case nidmm_grpc::FetchWaveformRequest::MaximumTimeEnumCase::kMaximumTime:
+          maximum_time = (ViInt32)request->maximum_time();
+          break;
+        case nidmm_grpc::FetchWaveformRequest::MaximumTimeEnumCase::kMaximumTimeRaw:
+          maximum_time = (ViInt32)request->maximum_time_raw();
+          break;
+        case nidmm_grpc::FetchWaveformRequest::MaximumTimeEnumCase::MAXIMUM_TIME_ENUM_NOT_SET:
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for maximum_time was not specified or out of range");
+          break;
+      }
+
       ViInt32 array_size = request->array_size();
       response->mutable_waveform_array()->Resize(array_size, 0);
       ViReal64* waveform_array = response->mutable_waveform_array()->mutable_data();
@@ -2227,7 +2311,19 @@ namespace nidmm_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 maximum_time = request->maximum_time();
+      ViInt32 maximum_time;
+      switch (request->maximum_time_enum_case()) {
+        case nidmm_grpc::ReadRequest::MaximumTimeEnumCase::kMaximumTime:
+          maximum_time = (ViInt32)request->maximum_time();
+          break;
+        case nidmm_grpc::ReadRequest::MaximumTimeEnumCase::kMaximumTimeRaw:
+          maximum_time = (ViInt32)request->maximum_time_raw();
+          break;
+        case nidmm_grpc::ReadRequest::MaximumTimeEnumCase::MAXIMUM_TIME_ENUM_NOT_SET:
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for maximum_time was not specified or out of range");
+          break;
+      }
+
       ViReal64 reading {};
       auto status = library_->Read(vi, maximum_time, &reading);
       response->set_status(status);
@@ -2251,7 +2347,19 @@ namespace nidmm_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 maximum_time = request->maximum_time();
+      ViInt32 maximum_time;
+      switch (request->maximum_time_enum_case()) {
+        case nidmm_grpc::ReadMultiPointRequest::MaximumTimeEnumCase::kMaximumTime:
+          maximum_time = (ViInt32)request->maximum_time();
+          break;
+        case nidmm_grpc::ReadMultiPointRequest::MaximumTimeEnumCase::kMaximumTimeRaw:
+          maximum_time = (ViInt32)request->maximum_time_raw();
+          break;
+        case nidmm_grpc::ReadMultiPointRequest::MaximumTimeEnumCase::MAXIMUM_TIME_ENUM_NOT_SET:
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for maximum_time was not specified or out of range");
+          break;
+      }
+
       ViInt32 array_size = request->array_size();
       response->mutable_reading_array()->Resize(array_size, 0);
       ViReal64* reading_array = response->mutable_reading_array()->mutable_data();
@@ -2304,7 +2412,19 @@ namespace nidmm_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 maximum_time = request->maximum_time();
+      ViInt32 maximum_time;
+      switch (request->maximum_time_enum_case()) {
+        case nidmm_grpc::ReadWaveformRequest::MaximumTimeEnumCase::kMaximumTime:
+          maximum_time = (ViInt32)request->maximum_time();
+          break;
+        case nidmm_grpc::ReadWaveformRequest::MaximumTimeEnumCase::kMaximumTimeRaw:
+          maximum_time = (ViInt32)request->maximum_time_raw();
+          break;
+        case nidmm_grpc::ReadWaveformRequest::MaximumTimeEnumCase::MAXIMUM_TIME_ENUM_NOT_SET:
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for maximum_time was not specified or out of range");
+          break;
+      }
+
       ViInt32 array_size = request->array_size();
       response->mutable_waveform_array()->Resize(array_size, 0);
       ViReal64* waveform_array = response->mutable_waveform_array()->mutable_data();

--- a/source/codegen/metadata/nidmm/CHANGES.md
+++ b/source/codegen/metadata/nidmm/CHANGES.md
@@ -43,6 +43,12 @@ Metadata for following attributes added:
 - `'POWERLINE_FREQ'`
 - `'RANGE'`
 - `'TRIGGER_DELAY'`
+- `'FREQ_VOLTAGE_RANGE'`
+- `'SAMPLE_INTERVAL'`
+- `'TRIGGER_COUNT'`
+- `'SAMPLE_COUNT'`
+
+`'FREQ_VOLTAGE_AUTO_RANGE'` (from nimi-python) changed to `'FREQ_VOLTAGE_AUTO_RANGE_VALUE'` to match the nidmm.h
 
 ## enums.py
 
@@ -66,6 +72,11 @@ Metadata for following enums added:
 - `'Range'`
 - `'SettleTime'`
 - `'TriggerDelays'`
+- `'FrequencyVoltageRange'`
+- `'SampleInterval'`
+- `'TriggerCount'`
+- `'SampleCount'`
+- `'TimeLimit'`
 
 `'NIDMM_VAL_FIXED'` (from nimi-python) changed to `'NIDMM_VAL_TEMP_REF_JUNC_FIXED'` in the `'ThermocoupleReferenceJunctionType'` to match the documentation and the header file
 
@@ -97,12 +108,22 @@ with the session_repository.
 - `InitExtCal` : Added a 'custom_close' tag to this function, since this API has a corresponding close function called 'CloseExtCal'
 
 `'enum'` tag added to the following functions:
-- `'apertureTime`' parameter of function `'GetApertureTimeInfo'`
-- `'action`' parameter of function `'CloseExtCal'`
-- `'calType`' parameter of function `'CalibrationType'`
-- `'offsetCompOhms`' parameter of function `'ConfigureOffsetCompOhms'`
-- `'configuration`' parameter of function `'Control4022'`
-- `'type`' parameter of function `'CalAdjustMisc'`
-- `'powerLineFrequencyHz`' parameter of function `'ConfigurePowerLineFrequency'`
-- `'triggerDelay`' parameter of function `'ConfigureTrigger'`
-- `controlAction` parameter of function `'Control'`
+- `'apertureTime'` parameter of function `'GetApertureTimeInfo'`
+- `'action'` parameter of function `'CloseExtCal'`
+- `'calType'` parameter of function `'CalibrationType'`
+- `'offsetCompOhms'` parameter of function `'ConfigureOffsetCompOhms'`
+- `'configuration'` parameter of function `'Control4022'`
+- `'type'` parameter of function `'CalAdjustMisc'`
+- `'powerLineFrequencyHz'` parameter of function `'ConfigurePowerLineFrequency'`
+- `'triggerDelay'` parameter of function `'ConfigureTrigger'`
+- `'controlAction'` parameter of function `'Control'`
+- `'voltageRange'` parameter of function `'ConfigureFrequencyVoltageRange'`
+- `'sampleInterval'` parameter of function `'ConfigureMultiPoint'`
+- `'triggerCount'` parameter of function `'ConfigureMultiPoint'`
+- `'sampleCount'` parameter of function `'ConfigureMultiPoint'`
+- `'maximumTime'` parameter of function `'Fetch'`
+- `'maximumTime'` parameter of function `'FetchMultiPoint'`
+- `'maximumTime'` parameter of function `'FetchWaveform'`
+- `'maximumTime'` parameter of function `'Read'`
+- `'maximumTime'` parameter of function `'ReadMultiPoint'`
+- `'maximumTime'` parameter of function `'ReadWaveform'`

--- a/source/codegen/metadata/nidmm/CHANGES.md
+++ b/source/codegen/metadata/nidmm/CHANGES.md
@@ -32,6 +32,7 @@ Metadata for following attributes added:
 - `'LATENCY'`
 - `'SHUNT_VALUE'`
 - `'CONFIG_PRODUCT_NUMBER'`
+- `'RECORD_COERCIONS'`
 
 `'enum'` tags added to following attributes:
 - `'BUFFER_SIZE'`
@@ -49,6 +50,7 @@ Metadata for following attributes added:
 - `'SAMPLE_COUNT'`
 
 `'FREQ_VOLTAGE_AUTO_RANGE'` (from nimi-python) changed to `'FREQ_VOLTAGE_AUTO_RANGE_VALUE'` to match the nidmm.h
+
 
 ## enums.py
 

--- a/source/codegen/metadata/nidmm/attributes.py
+++ b/source/codegen/metadata/nidmm/attributes.py
@@ -30,7 +30,7 @@ attributes = {
     1050006: {
         'access': 'read-write',
         'channel_based': False,
-        'name': 'READ_COERCIONS',
+        'name': 'RECORD_COERCIONS',
         'resettable': False,
         'type': 'ViBoolean'
     },
@@ -308,7 +308,7 @@ attributes = {
     1150044: {
         'access': 'read only',
         'channel_based': False,
-        'name': 'FREQ_VOLTAGE_AUTO_RANGE',
+        'name': 'FREQ_VOLTAGE_AUTO_RANGE_VALUE',
         'resettable': False,
         'type': 'ViReal64'
     },
@@ -509,6 +509,7 @@ attributes = {
         'access': 'read-write',
         'channel_based': False,
         'name': 'FREQ_VOLTAGE_RANGE',
+        'enum': 'FrequencyVoltageRange',
         'resettable': False,
         'type': 'ViReal64'
     },
@@ -554,6 +555,7 @@ attributes = {
         'access': 'read-write',
         'channel_based': False,
         'name': 'SAMPLE_COUNT',
+        'enum': 'SampleCount',
         'resettable': False,
         'type': 'ViInt32'
     },
@@ -570,6 +572,7 @@ attributes = {
         'attribute_class': 'AttributeViReal64TimeDeltaSeconds',
         'channel_based': False,
         'name': 'SAMPLE_INTERVAL',
+        'enum': 'SampleInterval',
         'resettable': False,
         'type': 'ViReal64',
         'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
@@ -578,6 +581,7 @@ attributes = {
         'access': 'read-write',
         'channel_based': False,
         'name': 'TRIGGER_COUNT',
+        'enum': 'TiggerCount',
         'resettable': False,
         'type': 'ViInt32'
     },

--- a/source/codegen/metadata/nidmm/enums.py
+++ b/source/codegen/metadata/nidmm/enums.py
@@ -237,6 +237,18 @@ enums = {
             }
         ]
     },
+    'FrequencyVoltageRange': {
+        'values': [
+            {
+                'name': 'NIDMM_VAL_AUTO_RANGE_ON',
+                'value': -1
+            },
+            {
+                'name': 'NIDMM_VAL_AUTO_RANGE_OFF',
+                'value': -2
+            }
+        ]
+    },
     'Function': {
         'values': [
             {
@@ -541,6 +553,22 @@ enums = {
             }
         ]
     },
+    'SampleCount': {
+        'values': [
+            {
+                'name': 'NIDMM_VAL_SAMPLE_COUNT_INFINITE',
+                'value': 0
+            }
+        ]
+    },
+    'SampleInterval': {
+        'values': [
+            {
+                'name': 'NIDMM_VAL_AUTO_DELAY',
+                'value': -1
+            }
+        ]
+    },
     'SampleTrigSlope': {
         'values': [
             {
@@ -689,6 +717,14 @@ enums = {
             }
         ]
     },
+    'TimeLimit': {
+        'values': [
+            {
+                'name': 'NIDMM_VAL_TIME_LIMIT_AUTO',
+                'value': -1
+            }
+        ]
+    },
     'TransducerType': {
         'values': [
             {
@@ -706,6 +742,14 @@ enums = {
             {
                 'name': 'NIDMM_VAL_4_WIRE_RTD',
                 'value': 4
+            }
+        ]
+    },
+    'TriggerCount': {
+        'values': [
+            {
+                'name': 'NIDMM_VAL_TRIG_COUNT_INFINITE',
+                'value': 0
             }
         ]
     },

--- a/source/codegen/metadata/nidmm/functions.py
+++ b/source/codegen/metadata/nidmm/functions.py
@@ -452,7 +452,8 @@ functions = {
         {
             "name": "voltageRange",
             "direction": "in",
-            "type": "ViReal64"
+            "type": "ViReal64",
+            "enum": "FrequencyVoltageRange"
         }
         ],
         "returns": "ViStatus"
@@ -549,12 +550,14 @@ functions = {
             {
                 'direction': 'in',
                 'name': 'triggerCount',
-                'type': 'ViInt32'
+                'type': 'ViInt32',
+                'enum': 'TriggerCount'
             },
             {
                 'direction': 'in',
                 'name': 'sampleCount',
-                'type': 'ViInt32'
+                'type': 'ViInt32',
+                'enum': 'SampleCount'
             },
             {
                 'default_value': 'SampleTrigger.IMMEDIATE',
@@ -567,6 +570,7 @@ functions = {
                 'direction': 'in',
                 'name': 'sampleInterval',
                 'type': 'ViReal64',
+                'enum': 'SampleInterval'
             }
         ],
         'returns': 'ViStatus'
@@ -943,6 +947,7 @@ functions = {
                 'direction': 'in',
                 'name': 'maximumTime',
                 'type': 'ViInt32',
+                'enum': 'TimeLimit'
             },
             {
                 'direction': 'out',
@@ -963,6 +968,7 @@ functions = {
                 'direction': 'in',
                 'name': 'maximumTime',
                 'type': 'ViInt32',
+                'enum': 'TimeLimit'
             },
             {
                 'direction': 'in',
@@ -998,6 +1004,7 @@ functions = {
                 'direction': 'in',
                 'name': 'maximumTime',
                 'type': 'ViInt32',
+                'enum': 'TimeLimit'
             },
             {
                 'direction': 'in',
@@ -1769,6 +1776,7 @@ functions = {
                 'direction': 'in',
                 'name': 'maximumTime',
                 'type': 'ViInt32',
+                'enum': 'TimeLimit'
             },
             {
                 'direction': 'out',
@@ -1789,6 +1797,7 @@ functions = {
                 'direction': 'in',
                 'name': 'maximumTime',
                 'type': 'ViInt32',
+                'enum': 'TimeLimit'
             },
             {
                 'direction': 'in',
@@ -1845,6 +1854,7 @@ functions = {
                 'direction': 'in',
                 'name': 'maximumTime',
                 'type': 'ViInt32',
+                'enum': 'TimeLimit'
             },
             {
                 'direction': 'in',

--- a/source/tests/system/nidmm_driver_api_tests.cpp
+++ b/source/tests/system/nidmm_driver_api_tests.cpp
@@ -361,7 +361,7 @@ TEST_F(NiDmmDriverApiTest, AcquireMeasurement_CompletesSuccesfully)
   ::grpc::ClientContext context;
   dmm::ReadRequest request;
   request.mutable_vi()->set_id(GetSessionId());
-  request.set_maximum_time(1000);
+  request.set_maximum_time_raw(1000);
   dmm::ReadResponse response;
   ::grpc::Status status = GetStub()->Read(&context, request, &response); 
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Added more of the missing enums from the nidmm.h to the metadata and generated
Attribute changes:
- `READ_COERCIONS` fixed to `RECORD_COERCIONS`
- `FREQ_VOLTAGE_AUTO_RANGE` fixed to `FREQ_VOLTAGE_AUTO_RANGE_VALUE`

Enums added:
- `FrequencyVoltageRange`
- `SampleCount`
- `SampleInterval`
- `TimeLimit`
- `TriggerCount`

### Why should this Pull Request be merged?

The added enums are used in attributes and function parameters

### What testing has been done?

The build ran successfully and the enums were generated in the proto file