### PR TITLE
[Owners] Remove NOT_FOUND status custom message in DCPower example. 

### DIFF
--- a/examples/nidcpower/measure-record.py
+++ b/examples/nidcpower/measure-record.py
@@ -199,8 +199,6 @@ except grpc.RpcError as rpc_error:
         error_message = f"Failed to connect to server on {server_address}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = "The operation is not implemented or is not supported/enabled in this service"
-    elif rpc_error.code() == grpc.StatusCode.NOT_FOUND:
-        error_message = "The requested function/entity was not found"
     print(f"{error_message}")
 
 finally:


### PR DESCRIPTION
### What does this Pull Request accomplish?

Error message returned by server for NOT_FOUND status code is more detailed and accurate as compared to the custom message that is displayed currently in example code.

### Why should this Pull Request be merged?

If any API is not present in dll then the corresponding server library function will store `NULL` value in its `function pointer` and hence will return a `LibraryLoadException` with `Could not find <name-of-the-function>` message. For ex.

![image](https://user-images.githubusercontent.com/78592845/117646356-48913f80-b1a9-11eb-9265-d62dd6d635d2.png)

The server returns `NOT_FOUND` error code in above scenario. If specific error code is not handled, the example still displays error message set by server. Hence removing those 2 lines from the code and not giving a custom message for NOT_FOUND status code would suffice.

### What testing has been done?

Manually tested