### PR TITLE
[Owners] [Tiny] Fixed mako template to use constants for bool to ViBoolean while doin…

### DIFF
--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -169,7 +169,7 @@ ${initialize_standard_input_param(function_name, parameter)}\
 % elif c_type == 'ViBoolean[]':
       auto ${parameter_name}_request = ${request_snippet};
       std::vector<${c_type_underlying_type}> ${parameter_name};
-      std::transform(${parameter_name}_request.begin(), ${parameter_name}_request.end(), std::back_inserter(${parameter_name}), [](auto x) { return (${c_type_underlying_type})x; });
+      std::transform(${parameter_name}_request.begin(), ${parameter_name}_request.end(), std::back_inserter(${parameter_name}), [](auto x) { return x ? VI_TRUE : VI_FALSE; });
 % elif 'enum' in parameter:
 <%
 PascalFieldName = common_helpers.snake_to_pascal(field_name)


### PR DESCRIPTION
### What does this Pull Request accomplish?

While adding support for ViBoolean[] parameters, we wanted to use `VI_TRUE` and `VI_FALSE` constants while transforming array elements. Earlier PR #55 which tried to address this comment updated generated `nifake_service.cpp` instead of fixing the mako template. In this PR I am updating mako template.

### Why should this Pull Request be merged?

Fixing mako template would ensure this change reflects in all future builds of server.

### What testing has been done?

Verified the generated code is as expected (no change from checked in file which was hand-fixed in earlier PR).