### PR TITLE
[Owners] [Tiny] Fixing deprecated function in DMM example

### DIFF
--- a/examples/nidmm/continuous-acquire-graph-multiple-points.py
+++ b/examples/nidmm/continuous-acquire-graph-multiple-points.py
@@ -131,7 +131,7 @@ try:
     fig = plt.gcf()
     fig.show()
     fig.canvas.draw()
-    fig.canvas.set_window_title('Measurements')
+    fig.canvas.manager.set_window_title('Measurements')
 
     # Handle closing of plot window
     closed = False


### PR DESCRIPTION
### What does this Pull Request accomplish?

Function `fig.canvas.set_window_title`, which has been deprecated in Matplotlib 3.4, is replaced with `fig.canvas.manager.set_window_title`, in the DMM example

### Why should this Pull Request be merged?

The function `fig.canvas.set_window_title` has been deprecated in Matplotlib 3.4 and it gives the following warning on use
 
![MicrosoftTeams-image](https://user-images.githubusercontent.com/32991453/117777392-2efc0080-b25a-11eb-9cec-1eb29d8f2c13.png)

To, fix this warning, the change has been made to use `fig.canvas.manager.set_window_title` instead

### What testing has been done?

The example has been tested on local machine