### PR TITLE
[Owners Review] Added unit test for ViSession[] in niFake

### DIFF
--- a/generated/nifake/nifake.proto
+++ b/generated/nifake/nifake.proto
@@ -18,6 +18,7 @@ import "session.proto";
 service NiFake {
   rpc Abort(AbortRequest) returns (AbortResponse);
   rpc AcceptListOfDurationsInSeconds(AcceptListOfDurationsInSecondsRequest) returns (AcceptListOfDurationsInSecondsResponse);
+  rpc AcceptViSessionArray(AcceptViSessionArrayRequest) returns (AcceptViSessionArrayResponse);
   rpc AcceptViUInt32Array(AcceptViUInt32ArrayRequest) returns (AcceptViUInt32ArrayResponse);
   rpc BoolArrayOutputFunction(BoolArrayOutputFunctionRequest) returns (BoolArrayOutputFunctionResponse);
   rpc BoolArrayInputFunction(BoolArrayInputFunctionRequest) returns (BoolArrayInputFunctionResponse);
@@ -136,6 +137,15 @@ message AcceptListOfDurationsInSecondsRequest {
 }
 
 message AcceptListOfDurationsInSecondsResponse {
+  int32 status = 1;
+}
+
+message AcceptViSessionArrayRequest {
+  uint32 session_count = 1;
+  repeated nidevice_grpc.Session session_array = 2;
+}
+
+message AcceptViSessionArrayResponse {
   int32 status = 1;
 }
 

--- a/generated/nifake/nifake_library.cpp
+++ b/generated/nifake/nifake_library.cpp
@@ -23,6 +23,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   }
   function_pointers_.Abort = reinterpret_cast<AbortPtr>(shared_library_.get_function_pointer("niFake_Abort"));
   function_pointers_.AcceptListOfDurationsInSeconds = reinterpret_cast<AcceptListOfDurationsInSecondsPtr>(shared_library_.get_function_pointer("niFake_AcceptListOfDurationsInSeconds"));
+  function_pointers_.AcceptViSessionArray = reinterpret_cast<AcceptViSessionArrayPtr>(shared_library_.get_function_pointer("niFake_AcceptViSessionArray"));
   function_pointers_.AcceptViUInt32Array = reinterpret_cast<AcceptViUInt32ArrayPtr>(shared_library_.get_function_pointer("niFake_AcceptViUInt32Array"));
   function_pointers_.BoolArrayOutputFunction = reinterpret_cast<BoolArrayOutputFunctionPtr>(shared_library_.get_function_pointer("niFake_BoolArrayOutputFunction"));
   function_pointers_.BoolArrayInputFunction = reinterpret_cast<BoolArrayInputFunctionPtr>(shared_library_.get_function_pointer("niFake_BoolArrayInputFunction"));
@@ -115,6 +116,18 @@ ViStatus NiFakeLibrary::AcceptListOfDurationsInSeconds(ViSession vi, ViInt32 cou
   return niFake_AcceptListOfDurationsInSeconds(vi, count, delays);
 #else
   return function_pointers_.AcceptListOfDurationsInSeconds(vi, count, delays);
+#endif
+}
+
+ViStatus NiFakeLibrary::AcceptViSessionArray(ViUInt32 sessionCount, ViSession sessionArray[])
+{
+  if (!function_pointers_.AcceptViSessionArray) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_AcceptViSessionArray.");
+  }
+#if defined(_MSC_VER)
+  return niFake_AcceptViSessionArray(sessionCount, sessionArray);
+#else
+  return function_pointers_.AcceptViSessionArray(sessionCount, sessionArray);
 #endif
 }
 

--- a/generated/nifake/nifake_library.h
+++ b/generated/nifake/nifake_library.h
@@ -20,6 +20,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ::grpc::Status check_function_exists(std::string functionName);
   ViStatus Abort(ViSession vi);
   ViStatus AcceptListOfDurationsInSeconds(ViSession vi, ViInt32 count, ViReal64 delays[]);
+  ViStatus AcceptViSessionArray(ViUInt32 sessionCount, ViSession sessionArray[]);
   ViStatus AcceptViUInt32Array(ViSession vi, ViInt32 arrayLen, ViUInt32 uInt32Array[]);
   ViStatus BoolArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
   ViStatus BoolArrayInputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
@@ -82,6 +83,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
  private:
   using AbortPtr = ViStatus (*)(ViSession vi);
   using AcceptListOfDurationsInSecondsPtr = ViStatus (*)(ViSession vi, ViInt32 count, ViReal64 delays[]);
+  using AcceptViSessionArrayPtr = ViStatus (*)(ViUInt32 sessionCount, ViSession sessionArray[]);
   using AcceptViUInt32ArrayPtr = ViStatus (*)(ViSession vi, ViInt32 arrayLen, ViUInt32 uInt32Array[]);
   using BoolArrayOutputFunctionPtr = ViStatus (*)(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
   using BoolArrayInputFunctionPtr = ViStatus (*)(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
@@ -144,6 +146,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   typedef struct FunctionPointers {
     AbortPtr Abort;
     AcceptListOfDurationsInSecondsPtr AcceptListOfDurationsInSeconds;
+    AcceptViSessionArrayPtr AcceptViSessionArray;
     AcceptViUInt32ArrayPtr AcceptViUInt32Array;
     BoolArrayOutputFunctionPtr BoolArrayOutputFunction;
     BoolArrayInputFunctionPtr BoolArrayInputFunction;

--- a/generated/nifake/nifake_library_interface.h
+++ b/generated/nifake/nifake_library_interface.h
@@ -17,6 +17,7 @@ class NiFakeLibraryInterface {
 
   virtual ViStatus Abort(ViSession vi) = 0;
   virtual ViStatus AcceptListOfDurationsInSeconds(ViSession vi, ViInt32 count, ViReal64 delays[]) = 0;
+  virtual ViStatus AcceptViSessionArray(ViUInt32 sessionCount, ViSession sessionArray[]) = 0;
   virtual ViStatus AcceptViUInt32Array(ViSession vi, ViInt32 arrayLen, ViUInt32 uInt32Array[]) = 0;
   virtual ViStatus BoolArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]) = 0;
   virtual ViStatus BoolArrayInputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]) = 0;

--- a/generated/nifake/nifake_mock_library.h
+++ b/generated/nifake/nifake_mock_library.h
@@ -19,6 +19,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
  public:
   MOCK_METHOD(ViStatus, Abort, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, AcceptListOfDurationsInSeconds, (ViSession vi, ViInt32 count, ViReal64 delays[]), (override));
+  MOCK_METHOD(ViStatus, AcceptViSessionArray, (ViUInt32 sessionCount, ViSession sessionArray[]), (override));
   MOCK_METHOD(ViStatus, AcceptViUInt32Array, (ViSession vi, ViInt32 arrayLen, ViUInt32 uInt32Array[]), (override));
   MOCK_METHOD(ViStatus, BoolArrayOutputFunction, (ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]), (override));
   MOCK_METHOD(ViStatus, BoolArrayInputFunction, (ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]), (override));

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -86,6 +86,31 @@ namespace nifake_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::AcceptViSessionArray(::grpc::ServerContext* context, const AcceptViSessionArrayRequest* request, AcceptViSessionArrayResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      ViUInt32 session_count = request->session_count();
+      auto session_array_request = request->session_array();
+      std::vector<ViSession> session_array;
+      std::transform(
+        session_array_request.begin(),
+        session_array_request.end(),
+        std::back_inserter(session_array),
+        [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
+      auto status = library_->AcceptViSessionArray(session_count, session_array.data());
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::AcceptViUInt32Array(::grpc::ServerContext* context, const AcceptViUInt32ArrayRequest* request, AcceptViUInt32ArrayResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -26,6 +26,7 @@ public:
   virtual ~NiFakeService();
   ::grpc::Status Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response) override;
   ::grpc::Status AcceptListOfDurationsInSeconds(::grpc::ServerContext* context, const AcceptListOfDurationsInSecondsRequest* request, AcceptListOfDurationsInSecondsResponse* response) override;
+  ::grpc::Status AcceptViSessionArray(::grpc::ServerContext* context, const AcceptViSessionArrayRequest* request, AcceptViSessionArrayResponse* response) override;
   ::grpc::Status AcceptViUInt32Array(::grpc::ServerContext* context, const AcceptViUInt32ArrayRequest* request, AcceptViUInt32ArrayResponse* response) override;
   ::grpc::Status BoolArrayOutputFunction(::grpc::ServerContext* context, const BoolArrayOutputFunctionRequest* request, BoolArrayOutputFunctionResponse* response) override;
   ::grpc::Status BoolArrayInputFunction(::grpc::ServerContext* context, const BoolArrayInputFunctionRequest* request, BoolArrayInputFunctionResponse* response) override;

--- a/source/codegen/metadata/nifake/CHANGES.md
+++ b/source/codegen/metadata/nifake/CHANGES.md
@@ -19,6 +19,8 @@ The following functions, not originally in nimi-python metadata, were newly adde
 	- This function allows testing of ViInt32[] output parameter
 - `'GetViUInt32Array'`
 	- This function allows testing of ViUInt32[] output parameter
+- `'AcceptViUInt32Array'`
+	- This function allows testing of ViSession[] input parameter
  
 The following functions were tagged with `'init_method': True,` to ensure their generated service handlers register the new session
 with the session_repository.

--- a/source/codegen/metadata/nifake/CHANGES.md
+++ b/source/codegen/metadata/nifake/CHANGES.md
@@ -19,7 +19,7 @@ The following functions, not originally in nimi-python metadata, were newly adde
 	- This function allows testing of ViInt32[] output parameter
 - `'GetViUInt32Array'`
 	- This function allows testing of ViUInt32[] output parameter
-- `'AcceptViUInt32Array'`
+- `'AcceptViSessionArray'`
 	- This function allows testing of ViSession[] input parameter
  
 The following functions were tagged with `'init_method': True,` to ensure their generated service handlers register the new session

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -57,7 +57,7 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
-    'AcceptViSessionArray':{
+    'AcceptViSessionArray': {
         'codegen_method': 'public',
         'parameters': [
             {
@@ -69,7 +69,7 @@ functions = {
                 'direction': 'in',
                 'name': 'sessionArray',
                 'type': 'ViSession[]',
-                'size':{
+                'size': {
                     'mechanism': 'passed-in',
                     'value': 'sessionCount'
                 }

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -57,6 +57,26 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'AcceptViSessionArray':{
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'sessionCount',
+                'type': 'ViUInt32'
+            },
+            {
+                'direction': 'in',
+                'name': 'sessionArray',
+                'type': 'ViSession[]',
+                'size':{
+                    'mechanism': 'passed-in',
+                    'value': 'sessionCount'
+                }
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'AcceptViUInt32Array': {
         'parameters': [
             {

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -40,6 +40,16 @@ std::uint32_t create_session(nidevice_grpc::SessionRepository& session_repo, ViS
   return session_id;
 }
 
+std::uint32_t create_session(std::string session_name, nidevice_grpc::SessionRepository& session_repo, ViSession sessionToStore)
+{
+  auto init_lambda = [&]() -> std::tuple<int, uint32_t> {
+    return std::make_tuple(0, sessionToStore);
+  };
+  uint32_t session_id;
+  session_repo.add_session(session_name, init_lambda, NULL, session_id);
+  return session_id;
+}
+
 // Init and Close function tests
 TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsSucceeds_CreatesAndStoresSession)
 {
@@ -1341,6 +1351,33 @@ TEST(NiFakeServiceTests, NiFakeService_GetViUInt32Array_CallsGetViUInt32Array)
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kDriverSuccess, response.status());
   EXPECT_THAT(response.u_int32_array(), ElementsAreArray(uint32_array, array_len));
+}
+
+TEST(NiFakeServiceTests, NiFakeService_AcceptViSessionArray_CallsAcceptViSessionArray)
+{
+  nidevice_grpc::SessionRepository session_repository;
+  std::uint32_t session_id1 = create_session("session1", session_repository, 12345671);
+  std::uint32_t session_id2 = create_session("session2", session_repository, 12345672);
+  std::uint32_t session_id3 = create_session("session3", session_repository, 12345673);
+  NiFakeMockLibrary library;
+  nifake_grpc::NiFakeService service(&library, &session_repository);
+  std::uint32_t session_count = 3;
+  ViSession session_array[] = {session_id1, session_id2, session_id3};
+  EXPECT_CALL(library, AcceptViSessionArray(session_count, _))
+      .With(Args<1, 0>(ElementsAreArray(session_array)))
+      .WillOnce(Return(kDriverSuccess));
+
+  ::grpc::ServerContext context;
+  nifake_grpc::AcceptViSessionArrayRequest request;
+  request.set_session_count(session_count);
+  request.add_session_array()->set_id(session_id1);
+  request.add_session_array()->set_id(session_id2);
+  request.add_session_array()->set_id(session_id3);
+  nifake_grpc::AcceptViSessionArrayResponse response;
+  ::grpc::Status status = service.AcceptViSessionArray(&context, &request, &response);
+
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(kDriverSuccess, response.status());
 }
 
 }  // namespace unit


### PR DESCRIPTION
### Justification

The support for ViSession[] was added in the mako script in some previous PR so unit test for the same is added in this PR.
Link to task: https://ni.visualstudio.com/DevCentral/_workitems/edit/1458047 

### Implementation

- We have to create different sessions for which there is already a `create_session` function present which returns `session_id` based on the fact whether there is already a session available with the given `session_name` or not. If there is then it will return the same session_id else will return value that it is passed as `sessionToStore`.
![image](https://user-images.githubusercontent.com/78592845/118806434-af5adb00-b8c4-11eb-8a03-940d78c11b7d.png)

- In this case I introduced a **new** `create_session` function with an extra parameter wherein we are required to pass the `session_name`.  This enables to get **distinct** `session_id` everytime we create a different session.
![image](https://user-images.githubusercontent.com/78592845/118806440-b1bd3500-b8c4-11eb-844c-45db0c4ca6c9.png)

- The internal implementation of `add_session` function enables us to get **distinct** `session_id` wrt **distinct** `session_name`.
![image](https://user-images.githubusercontent.com/78592845/118807103-8129cb00-b8c5-11eb-8f7f-8f4506541659.png)



### Testing

Manually ran the tests.
