### PR TITLE
[Owner Review] Removed Obsolete APIs from NI-FGEN

### DIFF
--- a/generated/nifgen/nifgen.proto
+++ b/generated/nifgen/nifgen.proto
@@ -51,14 +51,11 @@ service NiFgen {
   rpc ConfigureDigitalLevelScriptTrigger(ConfigureDigitalLevelScriptTriggerRequest) returns (ConfigureDigitalLevelScriptTriggerResponse);
   rpc ConfigureFreqList(ConfigureFreqListRequest) returns (ConfigureFreqListResponse);
   rpc ConfigureFrequency(ConfigureFrequencyRequest) returns (ConfigureFrequencyResponse);
-  rpc ConfigureGain(ConfigureGainRequest) returns (ConfigureGainResponse);
   rpc ConfigureOperationMode(ConfigureOperationModeRequest) returns (ConfigureOperationModeResponse);
   rpc ConfigureOutputEnabled(ConfigureOutputEnabledRequest) returns (ConfigureOutputEnabledResponse);
   rpc ConfigureOutputImpedance(ConfigureOutputImpedanceRequest) returns (ConfigureOutputImpedanceResponse);
   rpc ConfigureOutputMode(ConfigureOutputModeRequest) returns (ConfigureOutputModeResponse);
   rpc ConfigureP2pEndpointFullnessStartTrigger(ConfigureP2pEndpointFullnessStartTriggerRequest) returns (ConfigureP2pEndpointFullnessStartTriggerResponse);
-  rpc ConfigureRefClockFrequency(ConfigureRefClockFrequencyRequest) returns (ConfigureRefClockFrequencyResponse);
-  rpc ConfigureRefClockSource(ConfigureRefClockSourceRequest) returns (ConfigureRefClockSourceResponse);
   rpc ConfigureReferenceClock(ConfigureReferenceClockRequest) returns (ConfigureReferenceClockResponse);
   rpc ConfigureSampleClockSource(ConfigureSampleClockSourceRequest) returns (ConfigureSampleClockSourceResponse);
   rpc ConfigureSampleRate(ConfigureSampleRateRequest) returns (ConfigureSampleRateResponse);
@@ -67,8 +64,6 @@ service NiFgen {
   rpc ConfigureStandardWaveform(ConfigureStandardWaveformRequest) returns (ConfigureStandardWaveformResponse);
   rpc ConfigureSynchronization(ConfigureSynchronizationRequest) returns (ConfigureSynchronizationResponse);
   rpc ConfigureTriggerMode(ConfigureTriggerModeRequest) returns (ConfigureTriggerModeResponse);
-  rpc ConfigureTriggerSource(ConfigureTriggerSourceRequest) returns (ConfigureTriggerSourceResponse);
-  rpc ConfigureUpdateClockSource(ConfigureUpdateClockSourceRequest) returns (ConfigureUpdateClockSourceResponse);
   rpc CreateArbSequence(CreateArbSequenceRequest) returns (CreateArbSequenceResponse);
   rpc CreateFreqList(CreateFreqListRequest) returns (CreateFreqListResponse);
   rpc CreateWaveformF64(CreateWaveformF64Request) returns (CreateWaveformF64Response);
@@ -138,7 +133,6 @@ service NiFgen {
   rpc RouteSignalOut(RouteSignalOutRequest) returns (RouteSignalOutResponse);
   rpc SelfCal(SelfCalRequest) returns (SelfCalResponse);
   rpc SelfTest(SelfTestRequest) returns (SelfTestResponse);
-  rpc SendSoftwareTrigger(SendSoftwareTriggerRequest) returns (SendSoftwareTriggerResponse);
   rpc SetAttributeViBoolean(SetAttributeViBooleanRequest) returns (SetAttributeViBooleanResponse);
   rpc SetAttributeViInt32(SetAttributeViInt32Request) returns (SetAttributeViInt32Response);
   rpc SetAttributeViInt64(SetAttributeViInt64Request) returns (SetAttributeViInt64Response);
@@ -767,16 +761,6 @@ message ConfigureFrequencyResponse {
   int32 status = 1;
 }
 
-message ConfigureGainRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  double gain = 3;
-}
-
-message ConfigureGainResponse {
-  int32 status = 1;
-}
-
 message ConfigureOperationModeRequest {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
@@ -822,24 +806,6 @@ message ConfigureP2pEndpointFullnessStartTriggerRequest {
 }
 
 message ConfigureP2pEndpointFullnessStartTriggerResponse {
-  int32 status = 1;
-}
-
-message ConfigureRefClockFrequencyRequest {
-  nidevice_grpc.Session vi = 1;
-  double reference_clock_frequency = 2;
-}
-
-message ConfigureRefClockFrequencyResponse {
-  int32 status = 1;
-}
-
-message ConfigureRefClockSourceRequest {
-  nidevice_grpc.Session vi = 1;
-  sint32 reference_clock_source = 2;
-}
-
-message ConfigureRefClockSourceResponse {
   int32 status = 1;
 }
 
@@ -922,25 +888,6 @@ message ConfigureTriggerModeRequest {
 }
 
 message ConfigureTriggerModeResponse {
-  int32 status = 1;
-}
-
-message ConfigureTriggerSourceRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 trigger_source = 3;
-}
-
-message ConfigureTriggerSourceResponse {
-  int32 status = 1;
-}
-
-message ConfigureUpdateClockSourceRequest {
-  nidevice_grpc.Session vi = 1;
-  sint32 update_clock_source = 2;
-}
-
-message ConfigureUpdateClockSourceResponse {
   int32 status = 1;
 }
 
@@ -1635,14 +1582,6 @@ message SelfTestResponse {
   int32 status = 1;
   sint32 self_test_result = 2;
   string self_test_message = 3;
-}
-
-message SendSoftwareTriggerRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message SendSoftwareTriggerResponse {
-  int32 status = 1;
 }
 
 message SetAttributeViBooleanRequest {

--- a/generated/nifgen/nifgen_library.cpp
+++ b/generated/nifgen/nifgen_library.cpp
@@ -56,14 +56,11 @@ NiFgenLibrary::NiFgenLibrary() : shared_library_(kLibraryName)
   function_pointers_.ConfigureDigitalLevelScriptTrigger = reinterpret_cast<ConfigureDigitalLevelScriptTriggerPtr>(shared_library_.get_function_pointer("niFgen_ConfigureDigitalLevelScriptTrigger"));
   function_pointers_.ConfigureFreqList = reinterpret_cast<ConfigureFreqListPtr>(shared_library_.get_function_pointer("niFgen_ConfigureFreqList"));
   function_pointers_.ConfigureFrequency = reinterpret_cast<ConfigureFrequencyPtr>(shared_library_.get_function_pointer("niFgen_ConfigureFrequency"));
-  function_pointers_.ConfigureGain = reinterpret_cast<ConfigureGainPtr>(shared_library_.get_function_pointer("niFgen_ConfigureGain"));
   function_pointers_.ConfigureOperationMode = reinterpret_cast<ConfigureOperationModePtr>(shared_library_.get_function_pointer("niFgen_ConfigureOperationMode"));
   function_pointers_.ConfigureOutputEnabled = reinterpret_cast<ConfigureOutputEnabledPtr>(shared_library_.get_function_pointer("niFgen_ConfigureOutputEnabled"));
   function_pointers_.ConfigureOutputImpedance = reinterpret_cast<ConfigureOutputImpedancePtr>(shared_library_.get_function_pointer("niFgen_ConfigureOutputImpedance"));
   function_pointers_.ConfigureOutputMode = reinterpret_cast<ConfigureOutputModePtr>(shared_library_.get_function_pointer("niFgen_ConfigureOutputMode"));
   function_pointers_.ConfigureP2pEndpointFullnessStartTrigger = reinterpret_cast<ConfigureP2pEndpointFullnessStartTriggerPtr>(shared_library_.get_function_pointer("niFgen_ConfigureP2PEndpointFullnessStartTrigger"));
-  function_pointers_.ConfigureRefClockFrequency = reinterpret_cast<ConfigureRefClockFrequencyPtr>(shared_library_.get_function_pointer("niFgen_ConfigureRefClockFrequency"));
-  function_pointers_.ConfigureRefClockSource = reinterpret_cast<ConfigureRefClockSourcePtr>(shared_library_.get_function_pointer("niFgen_ConfigureRefClockSource"));
   function_pointers_.ConfigureReferenceClock = reinterpret_cast<ConfigureReferenceClockPtr>(shared_library_.get_function_pointer("niFgen_ConfigureReferenceClock"));
   function_pointers_.ConfigureSampleClockSource = reinterpret_cast<ConfigureSampleClockSourcePtr>(shared_library_.get_function_pointer("niFgen_ConfigureSampleClockSource"));
   function_pointers_.ConfigureSampleRate = reinterpret_cast<ConfigureSampleRatePtr>(shared_library_.get_function_pointer("niFgen_ConfigureSampleRate"));
@@ -72,8 +69,6 @@ NiFgenLibrary::NiFgenLibrary() : shared_library_(kLibraryName)
   function_pointers_.ConfigureStandardWaveform = reinterpret_cast<ConfigureStandardWaveformPtr>(shared_library_.get_function_pointer("niFgen_ConfigureStandardWaveform"));
   function_pointers_.ConfigureSynchronization = reinterpret_cast<ConfigureSynchronizationPtr>(shared_library_.get_function_pointer("niFgen_ConfigureSynchronization"));
   function_pointers_.ConfigureTriggerMode = reinterpret_cast<ConfigureTriggerModePtr>(shared_library_.get_function_pointer("niFgen_ConfigureTriggerMode"));
-  function_pointers_.ConfigureTriggerSource = reinterpret_cast<ConfigureTriggerSourcePtr>(shared_library_.get_function_pointer("niFgen_ConfigureTriggerSource"));
-  function_pointers_.ConfigureUpdateClockSource = reinterpret_cast<ConfigureUpdateClockSourcePtr>(shared_library_.get_function_pointer("niFgen_ConfigureUpdateClockSource"));
   function_pointers_.CreateArbSequence = reinterpret_cast<CreateArbSequencePtr>(shared_library_.get_function_pointer("niFgen_CreateArbSequence"));
   function_pointers_.CreateFreqList = reinterpret_cast<CreateFreqListPtr>(shared_library_.get_function_pointer("niFgen_CreateFreqList"));
   function_pointers_.CreateWaveformF64 = reinterpret_cast<CreateWaveformF64Ptr>(shared_library_.get_function_pointer("niFgen_CreateWaveformF64"));
@@ -143,7 +138,6 @@ NiFgenLibrary::NiFgenLibrary() : shared_library_(kLibraryName)
   function_pointers_.RouteSignalOut = reinterpret_cast<RouteSignalOutPtr>(shared_library_.get_function_pointer("niFgen_RouteSignalOut"));
   function_pointers_.SelfCal = reinterpret_cast<SelfCalPtr>(shared_library_.get_function_pointer("niFgen_SelfCal"));
   function_pointers_.SelfTest = reinterpret_cast<SelfTestPtr>(shared_library_.get_function_pointer("niFgen_self_test"));
-  function_pointers_.SendSoftwareTrigger = reinterpret_cast<SendSoftwareTriggerPtr>(shared_library_.get_function_pointer("niFgen_SendSoftwareTrigger"));
   function_pointers_.SetAttributeViBoolean = reinterpret_cast<SetAttributeViBooleanPtr>(shared_library_.get_function_pointer("niFgen_SetAttributeViBoolean"));
   function_pointers_.SetAttributeViInt32 = reinterpret_cast<SetAttributeViInt32Ptr>(shared_library_.get_function_pointer("niFgen_SetAttributeViInt32"));
   function_pointers_.SetAttributeViInt64 = reinterpret_cast<SetAttributeViInt64Ptr>(shared_library_.get_function_pointer("niFgen_SetAttributeViInt64"));
@@ -592,18 +586,6 @@ ViStatus NiFgenLibrary::ConfigureFrequency(ViSession vi, ViConstString channelNa
 #endif
 }
 
-ViStatus NiFgenLibrary::ConfigureGain(ViSession vi, ViConstString channelName, ViReal64 gain)
-{
-  if (!function_pointers_.ConfigureGain) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_ConfigureGain.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_ConfigureGain(vi, channelName, gain);
-#else
-  return function_pointers_.ConfigureGain(vi, channelName, gain);
-#endif
-}
-
 ViStatus NiFgenLibrary::ConfigureOperationMode(ViSession vi, ViConstString channelName, ViInt32 operationMode)
 {
   if (!function_pointers_.ConfigureOperationMode) {
@@ -661,30 +643,6 @@ ViStatus NiFgenLibrary::ConfigureP2pEndpointFullnessStartTrigger(ViSession vi, V
   return niFgen_ConfigureP2PEndpointFullnessStartTrigger(vi, p2pEndpointFullnessLevel);
 #else
   return function_pointers_.ConfigureP2pEndpointFullnessStartTrigger(vi, p2pEndpointFullnessLevel);
-#endif
-}
-
-ViStatus NiFgenLibrary::ConfigureRefClockFrequency(ViSession vi, ViReal64 referenceClockFrequency)
-{
-  if (!function_pointers_.ConfigureRefClockFrequency) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_ConfigureRefClockFrequency.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_ConfigureRefClockFrequency(vi, referenceClockFrequency);
-#else
-  return function_pointers_.ConfigureRefClockFrequency(vi, referenceClockFrequency);
-#endif
-}
-
-ViStatus NiFgenLibrary::ConfigureRefClockSource(ViSession vi, ViInt32 referenceClockSource)
-{
-  if (!function_pointers_.ConfigureRefClockSource) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_ConfigureRefClockSource.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_ConfigureRefClockSource(vi, referenceClockSource);
-#else
-  return function_pointers_.ConfigureRefClockSource(vi, referenceClockSource);
 #endif
 }
 
@@ -781,30 +739,6 @@ ViStatus NiFgenLibrary::ConfigureTriggerMode(ViSession vi, ViConstString channel
   return niFgen_ConfigureTriggerMode(vi, channelName, triggerMode);
 #else
   return function_pointers_.ConfigureTriggerMode(vi, channelName, triggerMode);
-#endif
-}
-
-ViStatus NiFgenLibrary::ConfigureTriggerSource(ViSession vi, ViConstString channelName, ViInt32 triggerSource)
-{
-  if (!function_pointers_.ConfigureTriggerSource) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_ConfigureTriggerSource.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_ConfigureTriggerSource(vi, channelName, triggerSource);
-#else
-  return function_pointers_.ConfigureTriggerSource(vi, channelName, triggerSource);
-#endif
-}
-
-ViStatus NiFgenLibrary::ConfigureUpdateClockSource(ViSession vi, ViInt32 updateClockSource)
-{
-  if (!function_pointers_.ConfigureUpdateClockSource) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_ConfigureUpdateClockSource.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_ConfigureUpdateClockSource(vi, updateClockSource);
-#else
-  return function_pointers_.ConfigureUpdateClockSource(vi, updateClockSource);
 #endif
 }
 
@@ -1633,18 +1567,6 @@ ViStatus NiFgenLibrary::SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar s
   return niFgen_self_test(vi, selfTestResult, selfTestMessage);
 #else
   return function_pointers_.SelfTest(vi, selfTestResult, selfTestMessage);
-#endif
-}
-
-ViStatus NiFgenLibrary::SendSoftwareTrigger(ViSession vi)
-{
-  if (!function_pointers_.SendSoftwareTrigger) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_SendSoftwareTrigger.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_SendSoftwareTrigger(vi);
-#else
-  return function_pointers_.SendSoftwareTrigger(vi);
 #endif
 }
 

--- a/generated/nifgen/nifgen_library.h
+++ b/generated/nifgen/nifgen_library.h
@@ -53,14 +53,11 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus ConfigureDigitalLevelScriptTrigger(ViSession vi, ViConstString triggerId, ViConstString source, ViInt32 triggerWhen);
   ViStatus ConfigureFreqList(ViSession vi, ViConstString channelName, ViInt32 frequencyListHandle, ViReal64 amplitude, ViReal64 dcOffset, ViReal64 startPhase);
   ViStatus ConfigureFrequency(ViSession vi, ViConstString channelName, ViReal64 frequency);
-  ViStatus ConfigureGain(ViSession vi, ViConstString channelName, ViReal64 gain);
   ViStatus ConfigureOperationMode(ViSession vi, ViConstString channelName, ViInt32 operationMode);
   ViStatus ConfigureOutputEnabled(ViSession vi, ViConstString channelName, ViBoolean enabled);
   ViStatus ConfigureOutputImpedance(ViSession vi, ViConstString channelName, ViReal64 impedance);
   ViStatus ConfigureOutputMode(ViSession vi, ViInt32 outputMode);
   ViStatus ConfigureP2pEndpointFullnessStartTrigger(ViSession vi, ViInt32 p2pEndpointFullnessLevel);
-  ViStatus ConfigureRefClockFrequency(ViSession vi, ViReal64 referenceClockFrequency);
-  ViStatus ConfigureRefClockSource(ViSession vi, ViInt32 referenceClockSource);
   ViStatus ConfigureReferenceClock(ViSession vi, ViConstString referenceClockSource, ViReal64 referenceClockFrequency);
   ViStatus ConfigureSampleClockSource(ViSession vi, ViConstString sampleClockSource);
   ViStatus ConfigureSampleRate(ViSession vi, ViReal64 sampleRate);
@@ -69,8 +66,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus ConfigureStandardWaveform(ViSession vi, ViConstString channelName, ViInt32 waveform, ViReal64 amplitude, ViReal64 dcOffset, ViReal64 frequency, ViReal64 startPhase);
   ViStatus ConfigureSynchronization(ViSession vi, ViConstString channelName, ViInt32 synchronizationSource);
   ViStatus ConfigureTriggerMode(ViSession vi, ViConstString channelName, ViInt32 triggerMode);
-  ViStatus ConfigureTriggerSource(ViSession vi, ViConstString channelName, ViInt32 triggerSource);
-  ViStatus ConfigureUpdateClockSource(ViSession vi, ViInt32 updateClockSource);
   ViStatus CreateArbSequence(ViSession vi, ViInt32 sequenceLength, ViInt32 waveformHandlesArray[], ViInt32 loopCountsArray[], ViInt32* sequenceHandle);
   ViStatus CreateFreqList(ViSession vi, ViInt32 waveform, ViInt32 frequencyListLength, ViReal64 frequencyArray[], ViReal64 durationArray[], ViInt32* frequencyListHandle);
   ViStatus CreateWaveformF64(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[], ViInt32* waveformHandle);
@@ -140,7 +135,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus RouteSignalOut(ViSession vi, ViConstString channelName, ViInt32 routeSignalFrom, ViInt32 routeSignalTo);
   ViStatus SelfCal(ViSession vi);
   ViStatus SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]);
-  ViStatus SendSoftwareTrigger(ViSession vi);
   ViStatus SetAttributeViBoolean(ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue);
   ViStatus SetAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue);
   ViStatus SetAttributeViInt64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue);
@@ -193,14 +187,11 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using ConfigureDigitalLevelScriptTriggerPtr = ViStatus (*)(ViSession vi, ViConstString triggerId, ViConstString source, ViInt32 triggerWhen);
   using ConfigureFreqListPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 frequencyListHandle, ViReal64 amplitude, ViReal64 dcOffset, ViReal64 startPhase);
   using ConfigureFrequencyPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViReal64 frequency);
-  using ConfigureGainPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViReal64 gain);
   using ConfigureOperationModePtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 operationMode);
   using ConfigureOutputEnabledPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViBoolean enabled);
   using ConfigureOutputImpedancePtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViReal64 impedance);
   using ConfigureOutputModePtr = ViStatus (*)(ViSession vi, ViInt32 outputMode);
   using ConfigureP2pEndpointFullnessStartTriggerPtr = ViStatus (*)(ViSession vi, ViInt32 p2pEndpointFullnessLevel);
-  using ConfigureRefClockFrequencyPtr = ViStatus (*)(ViSession vi, ViReal64 referenceClockFrequency);
-  using ConfigureRefClockSourcePtr = ViStatus (*)(ViSession vi, ViInt32 referenceClockSource);
   using ConfigureReferenceClockPtr = ViStatus (*)(ViSession vi, ViConstString referenceClockSource, ViReal64 referenceClockFrequency);
   using ConfigureSampleClockSourcePtr = ViStatus (*)(ViSession vi, ViConstString sampleClockSource);
   using ConfigureSampleRatePtr = ViStatus (*)(ViSession vi, ViReal64 sampleRate);
@@ -209,8 +200,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using ConfigureStandardWaveformPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 waveform, ViReal64 amplitude, ViReal64 dcOffset, ViReal64 frequency, ViReal64 startPhase);
   using ConfigureSynchronizationPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 synchronizationSource);
   using ConfigureTriggerModePtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 triggerMode);
-  using ConfigureTriggerSourcePtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 triggerSource);
-  using ConfigureUpdateClockSourcePtr = ViStatus (*)(ViSession vi, ViInt32 updateClockSource);
   using CreateArbSequencePtr = ViStatus (*)(ViSession vi, ViInt32 sequenceLength, ViInt32 waveformHandlesArray[], ViInt32 loopCountsArray[], ViInt32* sequenceHandle);
   using CreateFreqListPtr = ViStatus (*)(ViSession vi, ViInt32 waveform, ViInt32 frequencyListLength, ViReal64 frequencyArray[], ViReal64 durationArray[], ViInt32* frequencyListHandle);
   using CreateWaveformF64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[], ViInt32* waveformHandle);
@@ -280,7 +269,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using RouteSignalOutPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 routeSignalFrom, ViInt32 routeSignalTo);
   using SelfCalPtr = ViStatus (*)(ViSession vi);
   using SelfTestPtr = ViStatus (*)(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]);
-  using SendSoftwareTriggerPtr = ViStatus (*)(ViSession vi);
   using SetAttributeViBooleanPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue);
   using SetAttributeViInt32Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue);
   using SetAttributeViInt64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue);
@@ -333,14 +321,11 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
     ConfigureDigitalLevelScriptTriggerPtr ConfigureDigitalLevelScriptTrigger;
     ConfigureFreqListPtr ConfigureFreqList;
     ConfigureFrequencyPtr ConfigureFrequency;
-    ConfigureGainPtr ConfigureGain;
     ConfigureOperationModePtr ConfigureOperationMode;
     ConfigureOutputEnabledPtr ConfigureOutputEnabled;
     ConfigureOutputImpedancePtr ConfigureOutputImpedance;
     ConfigureOutputModePtr ConfigureOutputMode;
     ConfigureP2pEndpointFullnessStartTriggerPtr ConfigureP2pEndpointFullnessStartTrigger;
-    ConfigureRefClockFrequencyPtr ConfigureRefClockFrequency;
-    ConfigureRefClockSourcePtr ConfigureRefClockSource;
     ConfigureReferenceClockPtr ConfigureReferenceClock;
     ConfigureSampleClockSourcePtr ConfigureSampleClockSource;
     ConfigureSampleRatePtr ConfigureSampleRate;
@@ -349,8 +334,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
     ConfigureStandardWaveformPtr ConfigureStandardWaveform;
     ConfigureSynchronizationPtr ConfigureSynchronization;
     ConfigureTriggerModePtr ConfigureTriggerMode;
-    ConfigureTriggerSourcePtr ConfigureTriggerSource;
-    ConfigureUpdateClockSourcePtr ConfigureUpdateClockSource;
     CreateArbSequencePtr CreateArbSequence;
     CreateFreqListPtr CreateFreqList;
     CreateWaveformF64Ptr CreateWaveformF64;
@@ -420,7 +403,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
     RouteSignalOutPtr RouteSignalOut;
     SelfCalPtr SelfCal;
     SelfTestPtr SelfTest;
-    SendSoftwareTriggerPtr SendSoftwareTrigger;
     SetAttributeViBooleanPtr SetAttributeViBoolean;
     SetAttributeViInt32Ptr SetAttributeViInt32;
     SetAttributeViInt64Ptr SetAttributeViInt64;

--- a/generated/nifgen/nifgen_library_interface.h
+++ b/generated/nifgen/nifgen_library_interface.h
@@ -50,14 +50,11 @@ class NiFgenLibraryInterface {
   virtual ViStatus ConfigureDigitalLevelScriptTrigger(ViSession vi, ViConstString triggerId, ViConstString source, ViInt32 triggerWhen) = 0;
   virtual ViStatus ConfigureFreqList(ViSession vi, ViConstString channelName, ViInt32 frequencyListHandle, ViReal64 amplitude, ViReal64 dcOffset, ViReal64 startPhase) = 0;
   virtual ViStatus ConfigureFrequency(ViSession vi, ViConstString channelName, ViReal64 frequency) = 0;
-  virtual ViStatus ConfigureGain(ViSession vi, ViConstString channelName, ViReal64 gain) = 0;
   virtual ViStatus ConfigureOperationMode(ViSession vi, ViConstString channelName, ViInt32 operationMode) = 0;
   virtual ViStatus ConfigureOutputEnabled(ViSession vi, ViConstString channelName, ViBoolean enabled) = 0;
   virtual ViStatus ConfigureOutputImpedance(ViSession vi, ViConstString channelName, ViReal64 impedance) = 0;
   virtual ViStatus ConfigureOutputMode(ViSession vi, ViInt32 outputMode) = 0;
   virtual ViStatus ConfigureP2pEndpointFullnessStartTrigger(ViSession vi, ViInt32 p2pEndpointFullnessLevel) = 0;
-  virtual ViStatus ConfigureRefClockFrequency(ViSession vi, ViReal64 referenceClockFrequency) = 0;
-  virtual ViStatus ConfigureRefClockSource(ViSession vi, ViInt32 referenceClockSource) = 0;
   virtual ViStatus ConfigureReferenceClock(ViSession vi, ViConstString referenceClockSource, ViReal64 referenceClockFrequency) = 0;
   virtual ViStatus ConfigureSampleClockSource(ViSession vi, ViConstString sampleClockSource) = 0;
   virtual ViStatus ConfigureSampleRate(ViSession vi, ViReal64 sampleRate) = 0;
@@ -66,8 +63,6 @@ class NiFgenLibraryInterface {
   virtual ViStatus ConfigureStandardWaveform(ViSession vi, ViConstString channelName, ViInt32 waveform, ViReal64 amplitude, ViReal64 dcOffset, ViReal64 frequency, ViReal64 startPhase) = 0;
   virtual ViStatus ConfigureSynchronization(ViSession vi, ViConstString channelName, ViInt32 synchronizationSource) = 0;
   virtual ViStatus ConfigureTriggerMode(ViSession vi, ViConstString channelName, ViInt32 triggerMode) = 0;
-  virtual ViStatus ConfigureTriggerSource(ViSession vi, ViConstString channelName, ViInt32 triggerSource) = 0;
-  virtual ViStatus ConfigureUpdateClockSource(ViSession vi, ViInt32 updateClockSource) = 0;
   virtual ViStatus CreateArbSequence(ViSession vi, ViInt32 sequenceLength, ViInt32 waveformHandlesArray[], ViInt32 loopCountsArray[], ViInt32* sequenceHandle) = 0;
   virtual ViStatus CreateFreqList(ViSession vi, ViInt32 waveform, ViInt32 frequencyListLength, ViReal64 frequencyArray[], ViReal64 durationArray[], ViInt32* frequencyListHandle) = 0;
   virtual ViStatus CreateWaveformF64(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[], ViInt32* waveformHandle) = 0;
@@ -137,7 +132,6 @@ class NiFgenLibraryInterface {
   virtual ViStatus RouteSignalOut(ViSession vi, ViConstString channelName, ViInt32 routeSignalFrom, ViInt32 routeSignalTo) = 0;
   virtual ViStatus SelfCal(ViSession vi) = 0;
   virtual ViStatus SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]) = 0;
-  virtual ViStatus SendSoftwareTrigger(ViSession vi) = 0;
   virtual ViStatus SetAttributeViBoolean(ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue) = 0;
   virtual ViStatus SetAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue) = 0;
   virtual ViStatus SetAttributeViInt64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue) = 0;

--- a/generated/nifgen/nifgen_mock_library.h
+++ b/generated/nifgen/nifgen_mock_library.h
@@ -52,14 +52,11 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, ConfigureDigitalLevelScriptTrigger, (ViSession vi, ViConstString triggerId, ViConstString source, ViInt32 triggerWhen), (override));
   MOCK_METHOD(ViStatus, ConfigureFreqList, (ViSession vi, ViConstString channelName, ViInt32 frequencyListHandle, ViReal64 amplitude, ViReal64 dcOffset, ViReal64 startPhase), (override));
   MOCK_METHOD(ViStatus, ConfigureFrequency, (ViSession vi, ViConstString channelName, ViReal64 frequency), (override));
-  MOCK_METHOD(ViStatus, ConfigureGain, (ViSession vi, ViConstString channelName, ViReal64 gain), (override));
   MOCK_METHOD(ViStatus, ConfigureOperationMode, (ViSession vi, ViConstString channelName, ViInt32 operationMode), (override));
   MOCK_METHOD(ViStatus, ConfigureOutputEnabled, (ViSession vi, ViConstString channelName, ViBoolean enabled), (override));
   MOCK_METHOD(ViStatus, ConfigureOutputImpedance, (ViSession vi, ViConstString channelName, ViReal64 impedance), (override));
   MOCK_METHOD(ViStatus, ConfigureOutputMode, (ViSession vi, ViInt32 outputMode), (override));
   MOCK_METHOD(ViStatus, ConfigureP2pEndpointFullnessStartTrigger, (ViSession vi, ViInt32 p2pEndpointFullnessLevel), (override));
-  MOCK_METHOD(ViStatus, ConfigureRefClockFrequency, (ViSession vi, ViReal64 referenceClockFrequency), (override));
-  MOCK_METHOD(ViStatus, ConfigureRefClockSource, (ViSession vi, ViInt32 referenceClockSource), (override));
   MOCK_METHOD(ViStatus, ConfigureReferenceClock, (ViSession vi, ViConstString referenceClockSource, ViReal64 referenceClockFrequency), (override));
   MOCK_METHOD(ViStatus, ConfigureSampleClockSource, (ViSession vi, ViConstString sampleClockSource), (override));
   MOCK_METHOD(ViStatus, ConfigureSampleRate, (ViSession vi, ViReal64 sampleRate), (override));
@@ -68,8 +65,6 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, ConfigureStandardWaveform, (ViSession vi, ViConstString channelName, ViInt32 waveform, ViReal64 amplitude, ViReal64 dcOffset, ViReal64 frequency, ViReal64 startPhase), (override));
   MOCK_METHOD(ViStatus, ConfigureSynchronization, (ViSession vi, ViConstString channelName, ViInt32 synchronizationSource), (override));
   MOCK_METHOD(ViStatus, ConfigureTriggerMode, (ViSession vi, ViConstString channelName, ViInt32 triggerMode), (override));
-  MOCK_METHOD(ViStatus, ConfigureTriggerSource, (ViSession vi, ViConstString channelName, ViInt32 triggerSource), (override));
-  MOCK_METHOD(ViStatus, ConfigureUpdateClockSource, (ViSession vi, ViInt32 updateClockSource), (override));
   MOCK_METHOD(ViStatus, CreateArbSequence, (ViSession vi, ViInt32 sequenceLength, ViInt32 waveformHandlesArray[], ViInt32 loopCountsArray[], ViInt32* sequenceHandle), (override));
   MOCK_METHOD(ViStatus, CreateFreqList, (ViSession vi, ViInt32 waveform, ViInt32 frequencyListLength, ViReal64 frequencyArray[], ViReal64 durationArray[], ViInt32* frequencyListHandle), (override));
   MOCK_METHOD(ViStatus, CreateWaveformF64, (ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[], ViInt32* waveformHandle), (override));
@@ -139,7 +134,6 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, RouteSignalOut, (ViSession vi, ViConstString channelName, ViInt32 routeSignalFrom, ViInt32 routeSignalTo), (override));
   MOCK_METHOD(ViStatus, SelfCal, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, SelfTest, (ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]), (override));
-  MOCK_METHOD(ViStatus, SendSoftwareTrigger, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, SetAttributeViBoolean, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue), (override));
   MOCK_METHOD(ViStatus, SetAttributeViInt32, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue), (override));
   MOCK_METHOD(ViStatus, SetAttributeViInt64, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue), (override));

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -770,27 +770,6 @@ namespace nifgen_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::ConfigureGain(::grpc::ServerContext* context, const ConfigureGainRequest* request, ConfigureGainResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViConstString channel_name = request->channel_name().c_str();
-      ViReal64 gain = request->gain();
-      auto status = library_->ConfigureGain(vi, channel_name, gain);
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiFgenService::ConfigureOperationMode(::grpc::ServerContext* context, const ConfigureOperationModeRequest* request, ConfigureOperationModeResponse* response)
   {
     if (context->IsCancelled()) {
@@ -884,46 +863,6 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 p2p_endpoint_fullness_level = request->p2p_endpoint_fullness_level();
       auto status = library_->ConfigureP2pEndpointFullnessStartTrigger(vi, p2p_endpoint_fullness_level);
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::ConfigureRefClockFrequency(::grpc::ServerContext* context, const ConfigureRefClockFrequencyRequest* request, ConfigureRefClockFrequencyResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViReal64 reference_clock_frequency = request->reference_clock_frequency();
-      auto status = library_->ConfigureRefClockFrequency(vi, reference_clock_frequency);
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::ConfigureRefClockSource(::grpc::ServerContext* context, const ConfigureRefClockSourceRequest* request, ConfigureRefClockSourceResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 reference_clock_source = request->reference_clock_source();
-      auto status = library_->ConfigureRefClockSource(vi, reference_clock_source);
       response->set_status(status);
       return ::grpc::Status::OK;
     }
@@ -1103,47 +1042,6 @@ namespace nifgen_grpc {
       ViConstString channel_name = request->channel_name().c_str();
       ViInt32 trigger_mode = request->trigger_mode();
       auto status = library_->ConfigureTriggerMode(vi, channel_name, trigger_mode);
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::ConfigureTriggerSource(::grpc::ServerContext* context, const ConfigureTriggerSourceRequest* request, ConfigureTriggerSourceResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViConstString channel_name = request->channel_name().c_str();
-      ViInt32 trigger_source = request->trigger_source();
-      auto status = library_->ConfigureTriggerSource(vi, channel_name, trigger_source);
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::ConfigureUpdateClockSource(::grpc::ServerContext* context, const ConfigureUpdateClockSourceRequest* request, ConfigureUpdateClockSourceResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 update_clock_source = request->update_clock_source();
-      auto status = library_->ConfigureUpdateClockSource(vi, update_clock_source);
       response->set_status(status);
       return ::grpc::Status::OK;
     }
@@ -2817,25 +2715,6 @@ namespace nifgen_grpc {
         response->set_self_test_result(self_test_result);
         response->set_self_test_message(self_test_message);
       }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::SendSoftwareTrigger(::grpc::ServerContext* context, const SendSoftwareTriggerRequest* request, SendSoftwareTriggerResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      auto status = library_->SendSoftwareTrigger(vi);
-      response->set_status(status);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {

--- a/generated/nifgen/nifgen_service.h
+++ b/generated/nifgen/nifgen_service.h
@@ -59,14 +59,11 @@ public:
   ::grpc::Status ConfigureDigitalLevelScriptTrigger(::grpc::ServerContext* context, const ConfigureDigitalLevelScriptTriggerRequest* request, ConfigureDigitalLevelScriptTriggerResponse* response) override;
   ::grpc::Status ConfigureFreqList(::grpc::ServerContext* context, const ConfigureFreqListRequest* request, ConfigureFreqListResponse* response) override;
   ::grpc::Status ConfigureFrequency(::grpc::ServerContext* context, const ConfigureFrequencyRequest* request, ConfigureFrequencyResponse* response) override;
-  ::grpc::Status ConfigureGain(::grpc::ServerContext* context, const ConfigureGainRequest* request, ConfigureGainResponse* response) override;
   ::grpc::Status ConfigureOperationMode(::grpc::ServerContext* context, const ConfigureOperationModeRequest* request, ConfigureOperationModeResponse* response) override;
   ::grpc::Status ConfigureOutputEnabled(::grpc::ServerContext* context, const ConfigureOutputEnabledRequest* request, ConfigureOutputEnabledResponse* response) override;
   ::grpc::Status ConfigureOutputImpedance(::grpc::ServerContext* context, const ConfigureOutputImpedanceRequest* request, ConfigureOutputImpedanceResponse* response) override;
   ::grpc::Status ConfigureOutputMode(::grpc::ServerContext* context, const ConfigureOutputModeRequest* request, ConfigureOutputModeResponse* response) override;
   ::grpc::Status ConfigureP2pEndpointFullnessStartTrigger(::grpc::ServerContext* context, const ConfigureP2pEndpointFullnessStartTriggerRequest* request, ConfigureP2pEndpointFullnessStartTriggerResponse* response) override;
-  ::grpc::Status ConfigureRefClockFrequency(::grpc::ServerContext* context, const ConfigureRefClockFrequencyRequest* request, ConfigureRefClockFrequencyResponse* response) override;
-  ::grpc::Status ConfigureRefClockSource(::grpc::ServerContext* context, const ConfigureRefClockSourceRequest* request, ConfigureRefClockSourceResponse* response) override;
   ::grpc::Status ConfigureReferenceClock(::grpc::ServerContext* context, const ConfigureReferenceClockRequest* request, ConfigureReferenceClockResponse* response) override;
   ::grpc::Status ConfigureSampleClockSource(::grpc::ServerContext* context, const ConfigureSampleClockSourceRequest* request, ConfigureSampleClockSourceResponse* response) override;
   ::grpc::Status ConfigureSampleRate(::grpc::ServerContext* context, const ConfigureSampleRateRequest* request, ConfigureSampleRateResponse* response) override;
@@ -75,8 +72,6 @@ public:
   ::grpc::Status ConfigureStandardWaveform(::grpc::ServerContext* context, const ConfigureStandardWaveformRequest* request, ConfigureStandardWaveformResponse* response) override;
   ::grpc::Status ConfigureSynchronization(::grpc::ServerContext* context, const ConfigureSynchronizationRequest* request, ConfigureSynchronizationResponse* response) override;
   ::grpc::Status ConfigureTriggerMode(::grpc::ServerContext* context, const ConfigureTriggerModeRequest* request, ConfigureTriggerModeResponse* response) override;
-  ::grpc::Status ConfigureTriggerSource(::grpc::ServerContext* context, const ConfigureTriggerSourceRequest* request, ConfigureTriggerSourceResponse* response) override;
-  ::grpc::Status ConfigureUpdateClockSource(::grpc::ServerContext* context, const ConfigureUpdateClockSourceRequest* request, ConfigureUpdateClockSourceResponse* response) override;
   ::grpc::Status CreateArbSequence(::grpc::ServerContext* context, const CreateArbSequenceRequest* request, CreateArbSequenceResponse* response) override;
   ::grpc::Status CreateFreqList(::grpc::ServerContext* context, const CreateFreqListRequest* request, CreateFreqListResponse* response) override;
   ::grpc::Status CreateWaveformF64(::grpc::ServerContext* context, const CreateWaveformF64Request* request, CreateWaveformF64Response* response) override;
@@ -146,7 +141,6 @@ public:
   ::grpc::Status RouteSignalOut(::grpc::ServerContext* context, const RouteSignalOutRequest* request, RouteSignalOutResponse* response) override;
   ::grpc::Status SelfCal(::grpc::ServerContext* context, const SelfCalRequest* request, SelfCalResponse* response) override;
   ::grpc::Status SelfTest(::grpc::ServerContext* context, const SelfTestRequest* request, SelfTestResponse* response) override;
-  ::grpc::Status SendSoftwareTrigger(::grpc::ServerContext* context, const SendSoftwareTriggerRequest* request, SendSoftwareTriggerResponse* response) override;
   ::grpc::Status SetAttributeViBoolean(::grpc::ServerContext* context, const SetAttributeViBooleanRequest* request, SetAttributeViBooleanResponse* response) override;
   ::grpc::Status SetAttributeViInt32(::grpc::ServerContext* context, const SetAttributeViInt32Request* request, SetAttributeViInt32Response* response) override;
   ::grpc::Status SetAttributeViInt64(::grpc::ServerContext* context, const SetAttributeViInt64Request* request, SetAttributeViInt64Response* response) override;

--- a/source/codegen/metadata/nifgen/CHANGES.md
+++ b/source/codegen/metadata/nifgen/CHANGES.md
@@ -30,3 +30,11 @@ The following functions were tagged with their corresponding CNAME tag
 - SelfTest
 
 Added value_twist attribute to the coefficientsArray parameter of GetFirFilterCoefficients function.
+
+The following functions removed as they are obsolete:
+- ConfigureGain
+- ConfigureRefClockFrequency
+- ConfigureRefClockSource
+- ConfigureTriggerSource
+- ConfigureUpdateClockSource
+- SendSoftwareTrigger

--- a/source/codegen/metadata/nifgen/functions.py
+++ b/source/codegen/metadata/nifgen/functions.py
@@ -726,26 +726,6 @@ functions = {
         ],
         'returns':'ViStatus'
     },
-    'ConfigureGain':{
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
-                'type':'ViSession'
-            },
-            {
-                'name':'channelName',
-                'direction':'in',
-                'type':'ViConstString'
-            },
-            {
-                'name':'gain',
-                'direction':'in',
-                'type':'ViReal64'
-            }
-        ],
-        'returns':'ViStatus'
-    },
     'ConfigureOperationMode':{
         'parameters':[
             {
@@ -831,36 +811,6 @@ functions = {
             },
             {
                 'name':'p2pEndpointFullnessLevel',
-                'direction':'in',
-                'type':'ViInt32'
-            }
-        ],
-        'returns':'ViStatus'
-    },
-    'ConfigureRefClockFrequency':{
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
-                'type':'ViSession'
-            },
-            {
-                'name':'referenceClockFrequency',
-                'direction':'in',
-                'type':'ViReal64'
-            }
-        ],
-        'returns':'ViStatus'
-    },
-    'ConfigureRefClockSource':{
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
-                'type':'ViSession'
-            },
-            {
-                'name':'referenceClockSource',
                 'direction':'in',
                 'type':'ViInt32'
             }
@@ -1017,41 +967,6 @@ functions = {
             },
             {
                 'name':'triggerMode',
-                'direction':'in',
-                'type':'ViInt32'
-            }
-        ],
-        'returns':'ViStatus'
-    },
-    'ConfigureTriggerSource':{
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
-                'type':'ViSession'
-            },
-            {
-                'name':'channelName',
-                'direction':'in',
-                'type':'ViConstString'
-            },
-            {
-                'name':'triggerSource',
-                'direction':'in',
-                'type':'ViInt32'
-            }
-        ],
-        'returns':'ViStatus'
-    },
-    'ConfigureUpdateClockSource':{
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
-                'type':'ViSession'
-            },
-            {
-                'name':'updateClockSource',
                 'direction':'in',
                 'type':'ViInt32'
             }
@@ -2511,16 +2426,6 @@ functions = {
                     'mechanism':'fixed',
                     'value':256
                 }
-            }
-        ],
-        'returns':'ViStatus'
-    },
-    'SendSoftwareTrigger':{
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
-                'type':'ViSession'
             }
         ],
         'returns':'ViStatus'

--- a/source/tests/system/nifgen_driver_api_tests.cpp
+++ b/source/tests/system/nifgen_driver_api_tests.cpp
@@ -366,20 +366,6 @@ TEST_F(nifgenDriverApiTest, ConfigureTriggerMode_ConfiguresSuccessfully)
   EXPECT_EQ(expected_value, actual_trigger_mode);
 }
 
-TEST_F(nifgenDriverApiTest, SendSoftwareTrigger_TriggersSuccessfully)
-{
-  const char* channel_name = "0";
-  ViReal64 expected_current_level = 3.0;
-  ::grpc::ClientContext context;
-  fgen::SendSoftwareTriggerRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
-  fgen::SendSoftwareTriggerResponse response;
-  ::grpc::Status status = GetStub()->SendSoftwareTrigger(&context, request, &response);
-
-  EXPECT_TRUE(status.ok());
-  EXPECT_EQ(kfgenDriverApiSuccess, response.status());
-}
-
 TEST_F(nifgenDriverApiTest, ResetInterchangeCheck_ResetsSuccessfully)
 {
   const char* channel_name = "0";


### PR DESCRIPTION
### What does this Pull Request accomplish?

6 Obsolete APIs (present in niFgenObsolete.h) were added to the gRPC metadata as it was taken from the base hapigen metadata which has those APIs. These are removed from the metadata in this PR and the files are regenerated without the obsolete APIs
These are the APIs removed:
- ConfigureGain
- ConfigureRefClockFrequency
- ConfigureRefClockSource
- ConfigureTriggerSource
- ConfigureUpdateClockSource
- SendSoftwareTrigger

### Why should this Pull Request be merged?

Obsolete APIs removed

### What testing has been done?

Build is completing successfully and files generated