### PR TITLE
[Owner Review] Added support to close FGen example with Keyboard Interrupt 

### DIFF
--- a/examples/nifgen/basic-arbitrary-waveform.py
+++ b/examples/nifgen/basic-arbitrary-waveform.py
@@ -78,13 +78,13 @@ def ThrowOnError (vi, error_code):
 
 try:
     # Initalize NI-FGEN session
-    init_with_channels_resp = nifgen_service.InitWithOptions(nifgen_types.InitWithOptionsRequest(
+    init_with_options_resp = nifgen_service.InitWithOptions(nifgen_types.InitWithOptionsRequest(
         session_name = session_name,
         resource_name = resource,
         option_string = options
     ))
-    vi = init_with_channels_resp.vi
-    CheckForError(vi, init_with_channels_resp.status)
+    vi = init_with_options_resp.vi
+    CheckForError(vi, init_with_options_resp.status)
 
     # Configure channels
     config_channels_resp = nifgen_service.ConfigureChannels(nifgen_types.ConfigureChannelsRequest(
@@ -148,16 +148,19 @@ try:
     CheckForError(vi, init_gen_resp.status)
 
     print(f"Generating sine wave at {sample_rate} Hz...")
-    print('Close the window to stop generation')
+    print('Close the window or press Ctrl+C to stop generation')
 
-    # Plot the sine wave
-    fig = plt.gcf()
-    fig.canvas.manager.set_window_title('Sample Waveform')
-    plt.plot(sine)
-    plt.suptitle("Close the window to stop generation", fontsize=10)
-    plt.xlabel("Samples")
-    plt.ylabel("Amplitude")
-    plt.show()
+    try:
+        # Plot the sine wave
+        fig = plt.gcf()
+        fig.canvas.manager.set_window_title('Sample Waveform')
+        plt.plot(sine)
+        plt.suptitle("Close the window to stop generation", fontsize=10)
+        plt.xlabel("Samples")
+        plt.ylabel("Amplitude")
+        plt.show()
+    except KeyboardInterrupt:
+        pass
 
 # If NI-FGEN API throws an exception, print the error message  
 except grpc.RpcError as rpc_error:

--- a/examples/nifgen/basic-arbitrary-waveform.py
+++ b/examples/nifgen/basic-arbitrary-waveform.py
@@ -155,7 +155,7 @@ try:
         fig = plt.gcf()
         fig.canvas.manager.set_window_title('Sample Waveform')
         plt.plot(sine)
-        plt.suptitle("Close the window to stop generation", fontsize=10)
+        plt.suptitle("Close the window to stop generation", fontsize = 10)
         plt.xlabel("Samples")
         plt.ylabel("Amplitude")
         plt.show()


### PR DESCRIPTION
### What does this Pull Request accomplish?

In order to be consistent with other gRPC examples and to allow closing of example from commandline, feature of closing the example using Keyboard interrupt(Ctrl + C) has been added. Also, a variable name error has been fixed

### Why should this Pull Request be merged?

The example can now be closed with Keyboard Interrupt (Ctrl+C)

### What testing has been done?

The example is tested on local machine as well as PXI-5412 hardware