### PR TITLE
[Owners Review] Merge Issues resolved related to strings and addressed GetAttributeViString in TClk

### DIFF
--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -1274,7 +1274,7 @@ namespace nidigitalpattern_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViStatus error_code = request->error_code();
-      std::string error_message(256, '\0');
+      std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
@@ -1684,7 +1684,10 @@ namespace nidigitalpattern_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string value(buffer_size, '\0');
+      std::string value;
+      if (buffer_size > 0) {
+          value.resize(buffer_size-1);
+      }
       status = library_->GetAttributeViString(vi, channel_name, attribute, buffer_size, (ViChar*)value.data());
       response->set_status(status);
       if (status == 0) {
@@ -1716,7 +1719,10 @@ namespace nidigitalpattern_grpc {
       }
       ViInt32 name_buffer_size = status;
 
-      std::string name(name_buffer_size, '\0');
+      std::string name;
+      if (name_buffer_size > 0) {
+          name.resize(name_buffer_size-1);
+      }
       status = library_->GetChannelName(vi, index, name_buffer_size, (ViChar*)name.data());
       response->set_status(status);
       if (status == 0) {
@@ -1748,7 +1754,10 @@ namespace nidigitalpattern_grpc {
       }
       ViInt32 name_buffer_size = status;
 
-      std::string names(name_buffer_size, '\0');
+      std::string names;
+      if (name_buffer_size > 0) {
+          names.resize(name_buffer_size-1);
+      }
       status = library_->GetChannelNameFromString(vi, indices, name_buffer_size, (ViChar*)names.data());
       response->set_status(status);
       if (status == 0) {
@@ -1780,7 +1789,10 @@ namespace nidigitalpattern_grpc {
       ViInt32 error_description_buffer_size = status;
 
       ViStatus error_code {};
-      std::string error_description(error_description_buffer_size, '\0');
+      std::string error_description;
+      if (error_description_buffer_size > 0) {
+          error_description.resize(error_description_buffer_size-1);
+      }
       status = library_->GetError(vi, &error_code, error_description_buffer_size, (ViChar*)error_description.data());
       response->set_status(status);
       if (status == 0) {
@@ -1899,7 +1911,10 @@ namespace nidigitalpattern_grpc {
       }
       ViInt32 name_buffer_size = status;
 
-      std::string name(name_buffer_size, '\0');
+      std::string name;
+      if (name_buffer_size > 0) {
+          name.resize(name_buffer_size-1);
+      }
       status = library_->GetPatternName(vi, pattern_index, name_buffer_size, (ViChar*)name.data());
       response->set_status(status);
       if (status == 0) {
@@ -1931,7 +1946,10 @@ namespace nidigitalpattern_grpc {
       }
       ViInt32 pin_list_buffer_size = status;
 
-      std::string pin_list(pin_list_buffer_size, '\0');
+      std::string pin_list;
+      if (pin_list_buffer_size > 0) {
+          pin_list.resize(pin_list_buffer_size-1);
+      }
       status = library_->GetPatternPinList(vi, start_label, pin_list_buffer_size, (ViChar*)pin_list.data());
       response->set_status(status);
       if (status == 0) {
@@ -1963,7 +1981,10 @@ namespace nidigitalpattern_grpc {
       }
       ViInt32 name_buffer_size = status;
 
-      std::string name(name_buffer_size, '\0');
+      std::string name;
+      if (name_buffer_size > 0) {
+          name.resize(name_buffer_size-1);
+      }
       status = library_->GetPinName(vi, pin_index, name_buffer_size, (ViChar*)name.data());
       response->set_status(status);
       if (status == 0) {
@@ -2194,7 +2215,10 @@ namespace nidigitalpattern_grpc {
       }
       ViInt32 name_buffer_size = status;
 
-      std::string name(name_buffer_size, '\0');
+      std::string name;
+      if (name_buffer_size > 0) {
+          name.resize(name_buffer_size-1);
+      }
       status = library_->GetTimeSetName(vi, time_set_index, name_buffer_size, (ViChar*)name.data());
       response->set_status(status);
       if (status == 0) {
@@ -2980,7 +3004,7 @@ namespace nidigitalpattern_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 test_result {};
-      std::string test_message(2048, '\0');
+      std::string test_message(2048 - 1, '\0');
       auto status = library_->SelfTest(vi, &test_result, (ViChar*)test_message.data());
       response->set_status(status);
       if (status == 0) {

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -140,7 +140,10 @@ namespace nitclk_grpc {
       }
       ViUInt32 error_string_size = status;
 
-      std::string error_string(error_string_size, '\0');
+      std::string error_string;
+      if (error_string_size > 0) {
+          error_string.resize(error_string_size-1);
+      }
       status = library_->GetExtendedErrorInfo((ViChar*)error_string.data(), error_string_size);
       response->set_status(status);
       if (status == 0) {

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -126,39 +126,6 @@ namespace nitclk_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiTClkService::GetAttributeViString(::grpc::ServerContext* context, const GetAttributeViStringRequest* request, GetAttributeViStringResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto session_grpc_session = request->session();
-      ViSession session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
-      ViConstString channel_name = request->channel_name().c_str();
-      ViAttr attribute_id = request->attribute_id();
-
-      auto status = library_->GetAttributeViString(session, channel_name, attribute_id, 0, nullptr);
-      if (status < 0) {
-        response->set_status(status);
-        return ::grpc::Status::OK;
-      }
-      ViInt32 buf_size = status;
-
-      std::string value(buf_size, '\0');
-      status = library_->GetAttributeViString(session, channel_name, attribute_id, buf_size, (ViChar*)value.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_value(value);
-      }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiTClkService::GetExtendedErrorInfo(::grpc::ServerContext* context, const GetExtendedErrorInfoRequest* request, GetExtendedErrorInfoResponse* response)
   {
     if (context->IsCancelled()) {

--- a/source/codegen/metadata/nitclk/functions.py
+++ b/source/codegen/metadata/nitclk/functions.py
@@ -294,7 +294,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetAttributeViString': {
-        'codegen_method': 'public',
+        'codegen_method': 'CustomCode',
         'documentation': {
             'description': '\nThis function queries the value of an NI-TClk ViString attribute. You\nmust provide a ViChar array to serve as a buffer for the value. You pass\nthe number of bytes in the buffer as bufSize. If the current value of\nthe attribute, including the terminating NULL byte, is larger than the\nsize you indicate in bufSize, the function copies bufSize minus 1 bytes\ninto the buffer, places an ASCII NULL byte at the end of the buffer, and\nreturns the array size that you must pass to get the entire value. For\nexample, if the value is "123456" and bufSize is 4, the function places\n"123" into the buffer and returns 7. If you want to call\nniTClk_GetAttributeViString just to get the required array size, pass 0\nfor bufSize and VI_NULL for the value.\n'
         },

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -259,7 +259,7 @@ one_of_case_prefix = f'{namespace_prefix}{function_name}Request::{PascalFieldNam
 %     if common_helpers.is_struct(parameter) or underlying_param_type == 'ViBoolean':
       std::vector<${underlying_param_type}> ${parameter_name}(${size}, ${underlying_param_type}());
 ## Byte arrays are leveraging a string as a buffer, so we don't need to take special consideration of the null terminator.
-%     elif parameter['type'] == 'ViInt8[]':
+%     elif parameter['type'] in ['ViInt8[]', 'ViUInt8[]']:
       std::string ${parameter_name}(${size}, '\0');
 ## Driver string APIs require room in the buffer for the null terminator. We need to account for that when sizing the string.
 %     elif common_helpers.is_string_arg(parameter) and common_helpers.get_size_mechanism(parameter) == 'fixed':

--- a/source/custom/nitclk_service.custom.cpp
+++ b/source/custom/nitclk_service.custom.cpp
@@ -2,25 +2,6 @@
 #include <stdexcept>
 
 namespace nitclk_grpc {
-    
-class DriverErrorException : public std::runtime_error{
-  private:
-    int status_ = 0;
-
-  public:
-    DriverErrorException(int status) : std::runtime_error(""), status_(status) { }
-    int status() const
-    {
-      return status_;
-    }
-};
-
-static void CheckStatus(int status)
-{
-  if (status != 0) {
-    throw DriverErrorException(status);
-  }
-}
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
@@ -42,10 +23,7 @@ static void CheckStatus(int status)
       }
       ViInt32 buffer_size = status;
 
-      std::string value;
-      if (buffer_size > 0) {
-          value.resize(buffer_size);
-      }
+      std::string value(buffer_size, '\0');
       status = library_->GetAttributeViString(session, channel_name, attribute_id, buffer_size, (ViChar*)value.data());
       response->set_status(status);
       if (status == 0) {

--- a/source/custom/nitclk_service.custom.cpp
+++ b/source/custom/nitclk_service.custom.cpp
@@ -1,2 +1,61 @@
+#include <nitclk/nitclk_service.h>
+#include <stdexcept>
+
 namespace nitclk_grpc {
+    
+class DriverErrorException : public std::runtime_error{
+  private:
+    int status_ = 0;
+
+  public:
+    DriverErrorException(int status) : std::runtime_error(""), status_(status) { }
+    int status() const
+    {
+      return status_;
+    }
+};
+
+static void CheckStatus(int status)
+{
+  if (status != 0) {
+    throw DriverErrorException(status);
+  }
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiTClkService::GetAttributeViString(::grpc::ServerContext* context, const GetAttributeViStringRequest* request, GetAttributeViStringResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto session_grpc_session = request->session();
+      ViSession session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      ViConstString channel_name = request->channel_name().c_str();
+      ViAttr attribute_id = request->attribute_id();
+
+      auto status = library_->GetAttributeViString(session, channel_name, attribute_id, 0, nullptr);
+      if (status < 0) {
+        response->set_status(status);
+        return ::grpc::Status::OK;
+      }
+      ViInt32 buffer_size = status;
+
+      std::string value;
+      if (buffer_size > 0) {
+          value.resize(buffer_size);
+      }
+      status = library_->GetAttributeViString(session, channel_name, attribute_id, buffer_size, (ViChar*)value.data());
+      response->set_status(status);
+      if (status == 0) {
+        response->set_value(value);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
 }  // namespace nitclk_grpc

--- a/source/tests/system/nidigital_driver_api_tests.cpp
+++ b/source/tests/system/nidigital_driver_api_tests.cpp
@@ -447,7 +447,7 @@ TEST_F(NiDigitalDriverApiTest, ConfigureStartLabel_StartLabelConfigured)
   EXPECT_TRUE(status.ok());
   expect_api_success(response.status());
   std::string actual_start_label = get_string_attribute("", digital::NIDIGITAL_ATTRIBUTE_START_LABEL);
-  EXPECT_EQ(start_label, actual_start_label.substr(0, actual_start_label.size()-1));  // substring taken to remove the \0 at the end
+  EXPECT_EQ(start_label, actual_start_label);
 }
 
 }  // namespace system


### PR DESCRIPTION
### Justification

We are trying to merge from public repo to features/tclk-digitalpattern branch. While merging the main repo, the changes of the [PR](https://github.com/ni/grpc-device/pull/204) causes unintended changes for tclk and digital pattern. This PR fixes merge issues in temporary merge branch and will then eventually be used for merging changes from features/tclk-digitalpattern to public repo.

### Implementation

Issues encountered while merging : 
1) This [PR](https://github.com/ni/grpc-device/pull/204) uses **is_string_arg** for deciding string array resize. As **is_string_arg** now returns for **ViUInt8[]** as well so we have added exclusion for that during resize in **service_helpers.mako**.

2) Buffer size of string on using GetAttributeViString in TClk : 
In this [PR](https://github.com/ni/grpc-device/pull/204), the changes were made because the buffer size already incorporated the count for the terminating character '\0', Hence the string was resized to (buffer_size-1) before passing to the C-API so that no extra terminating character '\0' is introduced in the string.
After careful inspection, GetAttributeViString API in TClk returns only the count of the characters in the buffer_size ie it does not include terminating character '\0' in the count. For eg, if the string is "Hello World!", then 12 gets stored in the buffer_size instead of 13 which also makes sense acccording to what is mentioned in the chm for it.
![image](https://user-images.githubusercontent.com/78592845/121336466-29690780-c939-11eb-909c-029fa71e6e11.png)
In this case if the string is resized to (buffer_size-1) then this would lead to loss of the last character, hence GetAttributeViString for TClk is changed to codegen_method : CustomCode in metadata and is implemented in custom.cpp with resizing the string to (buffer_size) only to get the expected value.

### Testing

Manual
