### PR TITLE
[Owner Review] Updatd Fgen examples to use enums

### DIFF
--- a/examples/nifgen/basic-arbitrary-waveform.py
+++ b/examples/nifgen/basic-arbitrary-waveform.py
@@ -96,7 +96,7 @@ try:
     # Configure output mode
     config_out_resp = nifgen_service.ConfigureOutputMode(nifgen_types.ConfigureOutputModeRequest(
         vi = vi,
-        output_mode = 1
+        output_mode_raw = nifgen_types.OutputMode.OUTPUT_MODE_NIFGEN_VAL_OUTPUT_ARB
     ))
     CheckForError(vi, config_out_resp.status)
 
@@ -122,7 +122,7 @@ try:
     # Configure clockmode to VAL_HIGH_RESOLUTION
     config_clckmode_resp = nifgen_service.ConfigureClockMode(nifgen_types.ConfigureClockModeRequest(
         vi = vi,
-        clock_mode = 0
+        clock_mode = nifgen_types.ClockMode.CLOCK_MODE_NIFGEN_VAL_HIGH_RESOLUTION
     ))
     CheckForError(vi, config_clckmode_resp.status)
 

--- a/examples/nifgen/basic-arbitrary-waveform.py
+++ b/examples/nifgen/basic-arbitrary-waveform.py
@@ -96,7 +96,7 @@ try:
     # Configure output mode
     config_out_resp = nifgen_service.ConfigureOutputMode(nifgen_types.ConfigureOutputModeRequest(
         vi = vi,
-        output_mode_raw = nifgen_types.OutputMode.OUTPUT_MODE_NIFGEN_VAL_OUTPUT_ARB
+        output_mode = nifgen_types.OutputMode.OUTPUT_MODE_NIFGEN_VAL_OUTPUT_ARB
     ))
     CheckForError(vi, config_out_resp.status)
 

--- a/examples/nitclk/synchronize-tclk.py
+++ b/examples/nitclk/synchronize-tclk.py
@@ -99,7 +99,7 @@ try:
         # Configure output mode
         config_out_resp = nifgen_service.ConfigureOutputMode(nifgen_types.ConfigureOutputModeRequest(
             vi = vi,
-            output_mode = 1
+            output_mode = nifgen_types.OutputMode.OUTPUT_MODE_NIFGEN_VAL_OUTPUT_ARB
         ))
         
         # Configure sample rate

--- a/generated/nifgen/nifgen.proto
+++ b/generated/nifgen/nifgen.proto
@@ -717,7 +717,10 @@ message ConfigureChannelsResponse {
 
 message ConfigureClockModeRequest {
   nidevice_grpc.Session vi = 1;
-  sint32 clock_mode = 2;
+  oneof clock_mode_enum {
+    ClockMode clock_mode = 2;
+    sint32 clock_mode_raw = 3;
+  }
 }
 
 message ConfigureClockModeResponse {
@@ -821,7 +824,10 @@ message ConfigureOutputImpedanceResponse {
 
 message ConfigureOutputModeRequest {
   nidevice_grpc.Session vi = 1;
-  sint32 output_mode = 2;
+  oneof output_mode_enum {
+    OutputMode output_mode = 2;
+    sint32 output_mode_raw = 3;
+  }
 }
 
 message ConfigureOutputModeResponse {

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -660,7 +660,19 @@ namespace nifgen_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 clock_mode = request->clock_mode();
+      ViInt32 clock_mode;
+      switch (request->clock_mode_enum_case()) {
+        case nifgen_grpc::ConfigureClockModeRequest::ClockModeEnumCase::kClockMode:
+          clock_mode = (ViInt32)request->clock_mode();
+          break;
+        case nifgen_grpc::ConfigureClockModeRequest::ClockModeEnumCase::kClockModeRaw:
+          clock_mode = (ViInt32)request->clock_mode_raw();
+          break;
+        case nifgen_grpc::ConfigureClockModeRequest::ClockModeEnumCase::CLOCK_MODE_ENUM_NOT_SET:
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for clock_mode was not specified or out of range");
+          break;
+      }
+
       auto status = library_->ConfigureClockMode(vi, clock_mode);
       response->set_status(status);
       return ::grpc::Status::OK;
@@ -875,7 +887,19 @@ namespace nifgen_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 output_mode = request->output_mode();
+      ViInt32 output_mode;
+      switch (request->output_mode_enum_case()) {
+        case nifgen_grpc::ConfigureOutputModeRequest::OutputModeEnumCase::kOutputMode:
+          output_mode = (ViInt32)request->output_mode();
+          break;
+        case nifgen_grpc::ConfigureOutputModeRequest::OutputModeEnumCase::kOutputModeRaw:
+          output_mode = (ViInt32)request->output_mode_raw();
+          break;
+        case nifgen_grpc::ConfigureOutputModeRequest::OutputModeEnumCase::OUTPUT_MODE_ENUM_NOT_SET:
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for output_mode was not specified or out of range");
+          break;
+      }
+
       auto status = library_->ConfigureOutputMode(vi, output_mode);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/source/codegen/metadata/nifgen/functions.py
+++ b/source/codegen/metadata/nifgen/functions.py
@@ -566,7 +566,8 @@ functions = {
             {
                 'name':'clockMode',
                 'direction':'in',
-                'type':'ViInt32'
+                'type':'ViInt32',
+                'enum':'ClockMode'
             }
         ],
         'returns':'ViStatus'
@@ -795,7 +796,8 @@ functions = {
             {
                 'name':'outputMode',
                 'direction':'in',
-                'type':'ViInt32'
+                'type':'ViInt32',
+                'enum':'OutputMode'
             }
         ],
         'returns':'ViStatus'


### PR DESCRIPTION
### What does this Pull Request accomplish?

The examples using fgen were making use of raw values instead of the defined enums. So, they have been updated to use the enums. Also, 2 of the APIs which should be using enums as parameters(which are used in the examples) have been updated 

### Why should this Pull Request be merged?

Fgen examples now use enums

### What testing has been done?

Examples have been tested on PXI-5412 