### PR TITLE
[Owners review] Removing calibration functions

### DIFF
--- a/generated/nifgen/nifgen.proto
+++ b/generated/nifgen/nifgen.proto
@@ -66,7 +66,7 @@ service NiFgen {
   rpc CreateWaveformComplexF64(CreateWaveformComplexF64Request) returns (CreateWaveformComplexF64Response);
   rpc CreateWaveformF64(CreateWaveformF64Request) returns (CreateWaveformF64Response);
   rpc CreateWaveformFromFileF64(CreateWaveformFromFileF64Request) returns (CreateWaveformFromFileF64Response);
-  rpc CreateWaveformFromFileHWS(CreateWaveformFromFileHWSRequest) returns (CreateWaveformFromFileHWSResponse);
+  rpc CreateWaveformFromFileHws(CreateWaveformFromFileHwsRequest) returns (CreateWaveformFromFileHwsResponse);
   rpc CreateWaveformI16(CreateWaveformI16Request) returns (CreateWaveformI16Response);
   rpc CreateWaveformFromFileI16(CreateWaveformFromFileI16Request) returns (CreateWaveformFromFileI16Response);
   rpc DefineUserStandardWaveform(DefineUserStandardWaveformRequest) returns (DefineUserStandardWaveformResponse);
@@ -1241,7 +1241,7 @@ message CreateWaveformFromFileF64Response {
   sint32 waveform_handle = 2;
 }
 
-message CreateWaveformFromFileHWSRequest {
+message CreateWaveformFromFileHwsRequest {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
   string file_name = 3;
@@ -1249,7 +1249,7 @@ message CreateWaveformFromFileHWSRequest {
   bool use_gain_and_offset_from_waveform = 5;
 }
 
-message CreateWaveformFromFileHWSResponse {
+message CreateWaveformFromFileHwsResponse {
   int32 status = 1;
   sint32 waveform_handle = 2;
 }

--- a/generated/nifgen/nifgen.proto
+++ b/generated/nifgen/nifgen.proto
@@ -20,9 +20,6 @@ service NiFgen {
   rpc AdjustSampleClockRelativeDelay(AdjustSampleClockRelativeDelayRequest) returns (AdjustSampleClockRelativeDelayResponse);
   rpc AllocateNamedWaveform(AllocateNamedWaveformRequest) returns (AllocateNamedWaveformResponse);
   rpc AllocateWaveform(AllocateWaveformRequest) returns (AllocateWaveformResponse);
-  rpc CalAdjustDirectPathOutputImpedance(CalAdjustDirectPathOutputImpedanceRequest) returns (CalAdjustDirectPathOutputImpedanceResponse);
-  rpc CalAdjustMainPathOutputImpedance(CalAdjustMainPathOutputImpedanceRequest) returns (CalAdjustMainPathOutputImpedanceResponse);
-  rpc CalAdjustOscillatorFrequency(CalAdjustOscillatorFrequencyRequest) returns (CalAdjustOscillatorFrequencyResponse);
   rpc ChangeExtCalPassword(ChangeExtCalPasswordRequest) returns (ChangeExtCalPasswordResponse);
   rpc CheckAttributeViBoolean(CheckAttributeViBooleanRequest) returns (CheckAttributeViBooleanResponse);
   rpc CheckAttributeViInt32(CheckAttributeViInt32Request) returns (CheckAttributeViInt32Response);
@@ -38,7 +35,6 @@ service NiFgen {
   rpc ClearInterchangeWarnings(ClearInterchangeWarningsRequest) returns (ClearInterchangeWarningsResponse);
   rpc ClearUserStandardWaveform(ClearUserStandardWaveformRequest) returns (ClearUserStandardWaveformResponse);
   rpc Close(CloseRequest) returns (CloseResponse);
-  rpc CloseExtCal(CloseExtCalRequest) returns (CloseExtCalResponse);
   rpc Commit(CommitRequest) returns (CommitResponse);
   rpc ConfigureAmplitude(ConfigureAmplitudeRequest) returns (ConfigureAmplitudeResponse);
   rpc ConfigureArbSequence(ConfigureArbSequenceRequest) returns (ConfigureArbSequenceResponse);
@@ -70,7 +66,7 @@ service NiFgen {
   rpc CreateWaveformComplexF64(CreateWaveformComplexF64Request) returns (CreateWaveformComplexF64Response);
   rpc CreateWaveformF64(CreateWaveformF64Request) returns (CreateWaveformF64Response);
   rpc CreateWaveformFromFileF64(CreateWaveformFromFileF64Request) returns (CreateWaveformFromFileF64Response);
-  rpc CreateWaveformFromFileHws(CreateWaveformFromFileHwsRequest) returns (CreateWaveformFromFileHwsResponse);
+  rpc CreateWaveformFromFileHWS(CreateWaveformFromFileHWSRequest) returns (CreateWaveformFromFileHWSResponse);
   rpc CreateWaveformI16(CreateWaveformI16Request) returns (CreateWaveformI16Response);
   rpc CreateWaveformFromFileI16(CreateWaveformFromFileI16Request) returns (CreateWaveformFromFileI16Response);
   rpc DefineUserStandardWaveform(DefineUserStandardWaveformRequest) returns (DefineUserStandardWaveformResponse);
@@ -115,13 +111,8 @@ service NiFgen {
   rpc ImportAttributeConfigurationBuffer(ImportAttributeConfigurationBufferRequest) returns (ImportAttributeConfigurationBufferResponse);
   rpc ImportAttributeConfigurationFile(ImportAttributeConfigurationFileRequest) returns (ImportAttributeConfigurationFileResponse);
   rpc Init(InitRequest) returns (InitResponse);
-  rpc InitExtCal(InitExtCalRequest) returns (InitExtCalResponse);
   rpc InitWithOptions(InitWithOptionsRequest) returns (InitWithOptionsResponse);
   rpc InitializeWithChannels(InitializeWithChannelsRequest) returns (InitializeWithChannelsResponse);
-  rpc InitializeAnalogOutputCalibration(InitializeAnalogOutputCalibrationRequest) returns (InitializeAnalogOutputCalibrationResponse);
-  rpc InitializeCalADCCalibration(InitializeCalADCCalibrationRequest) returns (InitializeCalADCCalibrationResponse);
-  rpc InitializeFlatnessCalibration(InitializeFlatnessCalibrationRequest) returns (InitializeFlatnessCalibrationResponse);
-  rpc InitializeOscillatorFrequencyCalibration(InitializeOscillatorFrequencyCalibrationRequest) returns (InitializeOscillatorFrequencyCalibrationResponse);
   rpc InitiateGeneration(InitiateGenerationRequest) returns (InitiateGenerationResponse);
   rpc InvalidateAllAttributes(InvalidateAllAttributesRequest) returns (InvalidateAllAttributesResponse);
   rpc IsDone(IsDoneRequest) returns (IsDoneResponse);
@@ -130,7 +121,6 @@ service NiFgen {
   rpc QueryArbSeqCapabilities(QueryArbSeqCapabilitiesRequest) returns (QueryArbSeqCapabilitiesResponse);
   rpc QueryArbWfmCapabilities(QueryArbWfmCapabilitiesRequest) returns (QueryArbWfmCapabilitiesResponse);
   rpc QueryFreqListCapabilities(QueryFreqListCapabilitiesRequest) returns (QueryFreqListCapabilitiesResponse);
-  rpc ReadCalADC(ReadCalADCRequest) returns (ReadCalADCResponse);
   rpc ReadCurrentTemperature(ReadCurrentTemperatureRequest) returns (ReadCurrentTemperatureResponse);
   rpc Reset(ResetRequest) returns (ResetResponse);
   rpc ResetAttribute(ResetAttributeRequest) returns (ResetAttributeResponse);
@@ -154,7 +144,6 @@ service NiFgen {
   rpc SetWaveformNextWritePosition(SetWaveformNextWritePositionRequest) returns (SetWaveformNextWritePositionResponse);
   rpc UnlockSession(UnlockSessionRequest) returns (UnlockSessionResponse);
   rpc WaitUntilDone(WaitUntilDoneRequest) returns (WaitUntilDoneResponse);
-  rpc WriteBinary16AnalogStaticValue(WriteBinary16AnalogStaticValueRequest) returns (WriteBinary16AnalogStaticValueResponse);
   rpc WriteBinary16Waveform(WriteBinary16WaveformRequest) returns (WriteBinary16WaveformResponse);
   rpc WriteComplexBinary16Waveform(WriteComplexBinary16WaveformRequest) returns (WriteComplexBinary16WaveformResponse);
   rpc WriteNamedWaveformF64(WriteNamedWaveformF64Request) returns (WriteNamedWaveformF64Response);
@@ -773,42 +762,6 @@ message AllocateWaveformResponse {
   sint32 waveform_handle = 2;
 }
 
-message CalAdjustDirectPathOutputImpedanceRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 configuration = 3;
-  double load_impedance = 4;
-  double measured_source_voltage = 5;
-  double measured_voltage_across_load = 6;
-}
-
-message CalAdjustDirectPathOutputImpedanceResponse {
-  int32 status = 1;
-}
-
-message CalAdjustMainPathOutputImpedanceRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 configuration = 3;
-  double load_impedance = 4;
-  double measured_source_voltage = 5;
-  double measured_voltage_across_load = 6;
-}
-
-message CalAdjustMainPathOutputImpedanceResponse {
-  int32 status = 1;
-}
-
-message CalAdjustOscillatorFrequencyRequest {
-  nidevice_grpc.Session vi = 1;
-  double desired_frequency = 2;
-  double measured_frequency = 3;
-}
-
-message CalAdjustOscillatorFrequencyResponse {
-  int32 status = 1;
-}
-
 message ChangeExtCalPasswordRequest {
   nidevice_grpc.Session vi = 1;
   string old_password = 2;
@@ -950,15 +903,6 @@ message CloseRequest {
 }
 
 message CloseResponse {
-  int32 status = 1;
-}
-
-message CloseExtCalRequest {
-  nidevice_grpc.Session vi = 1;
-  sint32 action = 2;
-}
-
-message CloseExtCalResponse {
   int32 status = 1;
 }
 
@@ -1750,17 +1694,6 @@ message InitResponse {
   nidevice_grpc.Session vi = 2;
 }
 
-message InitExtCalRequest {
-  string session_name = 1;
-  string resource_name = 2;
-  string password = 3;
-}
-
-message InitExtCalResponse {
-  int32 status = 1;
-  nidevice_grpc.Session vi = 2;
-}
-
 message InitWithOptionsRequest {
   string session_name = 1;
   string resource_name = 2;
@@ -1785,38 +1718,6 @@ message InitializeWithChannelsRequest {
 message InitializeWithChannelsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-}
-
-message InitializeAnalogOutputCalibrationRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message InitializeAnalogOutputCalibrationResponse {
-  int32 status = 1;
-}
-
-message InitializeCalADCCalibrationRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message InitializeCalADCCalibrationResponse {
-  int32 status = 1;
-}
-
-message InitializeFlatnessCalibrationRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message InitializeFlatnessCalibrationResponse {
-  int32 status = 1;
-}
-
-message InitializeOscillatorFrequencyCalibrationRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message InitializeOscillatorFrequencyCalibrationResponse {
-  int32 status = 1;
 }
 
 message InitiateGenerationRequest {
@@ -1898,17 +1799,6 @@ message QueryFreqListCapabilitiesResponse {
   double minimum_frequency_list_duration = 5;
   double maximum_frequency_list_duration = 6;
   double frequency_list_duration_quantum = 7;
-}
-
-message ReadCalADCRequest {
-  nidevice_grpc.Session vi = 1;
-  sint32 number_of_reads_to_average = 2;
-  bool return_calibrated_value = 3;
-}
-
-message ReadCalADCResponse {
-  int32 status = 1;
-  double cal_adc_value = 2;
 }
 
 message ReadCurrentTemperatureRequest {
@@ -2142,16 +2032,6 @@ message WaitUntilDoneRequest {
 }
 
 message WaitUntilDoneResponse {
-  int32 status = 1;
-}
-
-message WriteBinary16AnalogStaticValueRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 value = 3;
-}
-
-message WriteBinary16AnalogStaticValueResponse {
   int32 status = 1;
 }
 

--- a/generated/nifgen/nifgen_library.cpp
+++ b/generated/nifgen/nifgen_library.cpp
@@ -71,7 +71,7 @@ NiFgenLibrary::NiFgenLibrary() : shared_library_(kLibraryName)
   function_pointers_.CreateWaveformComplexF64 = reinterpret_cast<CreateWaveformComplexF64Ptr>(shared_library_.get_function_pointer("niFgen_CreateWaveformComplexF64"));
   function_pointers_.CreateWaveformF64 = reinterpret_cast<CreateWaveformF64Ptr>(shared_library_.get_function_pointer("niFgen_CreateWaveformF64"));
   function_pointers_.CreateWaveformFromFileF64 = reinterpret_cast<CreateWaveformFromFileF64Ptr>(shared_library_.get_function_pointer("niFgen_CreateWaveformFromFileF64"));
-  function_pointers_.CreateWaveformFromFileHWS = reinterpret_cast<CreateWaveformFromFileHWSPtr>(shared_library_.get_function_pointer("niFgen_CreateWaveformFromFileHWS"));
+  function_pointers_.CreateWaveformFromFileHws = reinterpret_cast<CreateWaveformFromFileHwsPtr>(shared_library_.get_function_pointer("niFgen_CreateWaveformFromFileHWS"));
   function_pointers_.CreateWaveformI16 = reinterpret_cast<CreateWaveformI16Ptr>(shared_library_.get_function_pointer("niFgen_CreateWaveformI16"));
   function_pointers_.CreateWaveformFromFileI16 = reinterpret_cast<CreateWaveformFromFileI16Ptr>(shared_library_.get_function_pointer("niFgen_CreateWaveformFromFileI16"));
   function_pointers_.DefineUserStandardWaveform = reinterpret_cast<DefineUserStandardWaveformPtr>(shared_library_.get_function_pointer("niFgen_DefineUserStandardWaveform"));
@@ -772,15 +772,15 @@ ViStatus NiFgenLibrary::CreateWaveformFromFileF64(ViSession vi, ViConstString ch
 #endif
 }
 
-ViStatus NiFgenLibrary::CreateWaveformFromFileHWS(ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle)
+ViStatus NiFgenLibrary::CreateWaveformFromFileHws(ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle)
 {
-  if (!function_pointers_.CreateWaveformFromFileHWS) {
+  if (!function_pointers_.CreateWaveformFromFileHws) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFgen_CreateWaveformFromFileHWS.");
   }
 #if defined(_MSC_VER)
   return niFgen_CreateWaveformFromFileHWS(vi, channelName, fileName, useRateFromWaveform, useGainAndOffsetFromWaveform, waveformHandle);
 #else
-  return function_pointers_.CreateWaveformFromFileHWS(vi, channelName, fileName, useRateFromWaveform, useGainAndOffsetFromWaveform, waveformHandle);
+  return function_pointers_.CreateWaveformFromFileHws(vi, channelName, fileName, useRateFromWaveform, useGainAndOffsetFromWaveform, waveformHandle);
 #endif
 }
 

--- a/generated/nifgen/nifgen_library.cpp
+++ b/generated/nifgen/nifgen_library.cpp
@@ -25,9 +25,6 @@ NiFgenLibrary::NiFgenLibrary() : shared_library_(kLibraryName)
   function_pointers_.AdjustSampleClockRelativeDelay = reinterpret_cast<AdjustSampleClockRelativeDelayPtr>(shared_library_.get_function_pointer("niFgen_AdjustSampleClockRelativeDelay"));
   function_pointers_.AllocateNamedWaveform = reinterpret_cast<AllocateNamedWaveformPtr>(shared_library_.get_function_pointer("niFgen_AllocateNamedWaveform"));
   function_pointers_.AllocateWaveform = reinterpret_cast<AllocateWaveformPtr>(shared_library_.get_function_pointer("niFgen_AllocateWaveform"));
-  function_pointers_.CalAdjustDirectPathOutputImpedance = reinterpret_cast<CalAdjustDirectPathOutputImpedancePtr>(shared_library_.get_function_pointer("niFgen_CalAdjustDirectPathOutputImpedance"));
-  function_pointers_.CalAdjustMainPathOutputImpedance = reinterpret_cast<CalAdjustMainPathOutputImpedancePtr>(shared_library_.get_function_pointer("niFgen_CalAdjustMainPathOutputImpedance"));
-  function_pointers_.CalAdjustOscillatorFrequency = reinterpret_cast<CalAdjustOscillatorFrequencyPtr>(shared_library_.get_function_pointer("niFgen_CalAdjustOscillatorFrequency"));
   function_pointers_.ChangeExtCalPassword = reinterpret_cast<ChangeExtCalPasswordPtr>(shared_library_.get_function_pointer("niFgen_ChangeExtCalPassword"));
   function_pointers_.CheckAttributeViBoolean = reinterpret_cast<CheckAttributeViBooleanPtr>(shared_library_.get_function_pointer("niFgen_CheckAttributeViBoolean"));
   function_pointers_.CheckAttributeViInt32 = reinterpret_cast<CheckAttributeViInt32Ptr>(shared_library_.get_function_pointer("niFgen_CheckAttributeViInt32"));
@@ -43,7 +40,6 @@ NiFgenLibrary::NiFgenLibrary() : shared_library_(kLibraryName)
   function_pointers_.ClearInterchangeWarnings = reinterpret_cast<ClearInterchangeWarningsPtr>(shared_library_.get_function_pointer("niFgen_ClearInterchangeWarnings"));
   function_pointers_.ClearUserStandardWaveform = reinterpret_cast<ClearUserStandardWaveformPtr>(shared_library_.get_function_pointer("niFgen_ClearUserStandardWaveform"));
   function_pointers_.Close = reinterpret_cast<ClosePtr>(shared_library_.get_function_pointer("niFgen_close"));
-  function_pointers_.CloseExtCal = reinterpret_cast<CloseExtCalPtr>(shared_library_.get_function_pointer("niFgen_CloseExtCal"));
   function_pointers_.Commit = reinterpret_cast<CommitPtr>(shared_library_.get_function_pointer("niFgen_Commit"));
   function_pointers_.ConfigureAmplitude = reinterpret_cast<ConfigureAmplitudePtr>(shared_library_.get_function_pointer("niFgen_ConfigureAmplitude"));
   function_pointers_.ConfigureArbSequence = reinterpret_cast<ConfigureArbSequencePtr>(shared_library_.get_function_pointer("niFgen_ConfigureArbSequence"));
@@ -75,7 +71,7 @@ NiFgenLibrary::NiFgenLibrary() : shared_library_(kLibraryName)
   function_pointers_.CreateWaveformComplexF64 = reinterpret_cast<CreateWaveformComplexF64Ptr>(shared_library_.get_function_pointer("niFgen_CreateWaveformComplexF64"));
   function_pointers_.CreateWaveformF64 = reinterpret_cast<CreateWaveformF64Ptr>(shared_library_.get_function_pointer("niFgen_CreateWaveformF64"));
   function_pointers_.CreateWaveformFromFileF64 = reinterpret_cast<CreateWaveformFromFileF64Ptr>(shared_library_.get_function_pointer("niFgen_CreateWaveformFromFileF64"));
-  function_pointers_.CreateWaveformFromFileHws = reinterpret_cast<CreateWaveformFromFileHwsPtr>(shared_library_.get_function_pointer("niFgen_CreateWaveformFromFileHWS"));
+  function_pointers_.CreateWaveformFromFileHWS = reinterpret_cast<CreateWaveformFromFileHWSPtr>(shared_library_.get_function_pointer("niFgen_CreateWaveformFromFileHWS"));
   function_pointers_.CreateWaveformI16 = reinterpret_cast<CreateWaveformI16Ptr>(shared_library_.get_function_pointer("niFgen_CreateWaveformI16"));
   function_pointers_.CreateWaveformFromFileI16 = reinterpret_cast<CreateWaveformFromFileI16Ptr>(shared_library_.get_function_pointer("niFgen_CreateWaveformFromFileI16"));
   function_pointers_.DefineUserStandardWaveform = reinterpret_cast<DefineUserStandardWaveformPtr>(shared_library_.get_function_pointer("niFgen_DefineUserStandardWaveform"));
@@ -120,13 +116,8 @@ NiFgenLibrary::NiFgenLibrary() : shared_library_(kLibraryName)
   function_pointers_.ImportAttributeConfigurationBuffer = reinterpret_cast<ImportAttributeConfigurationBufferPtr>(shared_library_.get_function_pointer("niFgen_ImportAttributeConfigurationBuffer"));
   function_pointers_.ImportAttributeConfigurationFile = reinterpret_cast<ImportAttributeConfigurationFilePtr>(shared_library_.get_function_pointer("niFgen_ImportAttributeConfigurationFile"));
   function_pointers_.Init = reinterpret_cast<InitPtr>(shared_library_.get_function_pointer("niFgen_init "));
-  function_pointers_.InitExtCal = reinterpret_cast<InitExtCalPtr>(shared_library_.get_function_pointer("niFgen_InitExtCal"));
   function_pointers_.InitWithOptions = reinterpret_cast<InitWithOptionsPtr>(shared_library_.get_function_pointer("niFgen_InitWithOptions"));
   function_pointers_.InitializeWithChannels = reinterpret_cast<InitializeWithChannelsPtr>(shared_library_.get_function_pointer("niFgen_InitializeWithChannels"));
-  function_pointers_.InitializeAnalogOutputCalibration = reinterpret_cast<InitializeAnalogOutputCalibrationPtr>(shared_library_.get_function_pointer("niFgen_InitializeAnalogOutputCalibration"));
-  function_pointers_.InitializeCalADCCalibration = reinterpret_cast<InitializeCalADCCalibrationPtr>(shared_library_.get_function_pointer("niFgen_InitializeCalADCCalibration"));
-  function_pointers_.InitializeFlatnessCalibration = reinterpret_cast<InitializeFlatnessCalibrationPtr>(shared_library_.get_function_pointer("niFgen_InitializeFlatnessCalibration"));
-  function_pointers_.InitializeOscillatorFrequencyCalibration = reinterpret_cast<InitializeOscillatorFrequencyCalibrationPtr>(shared_library_.get_function_pointer("niFgen_InitializeOscillatorFrequencyCalibration"));
   function_pointers_.InitiateGeneration = reinterpret_cast<InitiateGenerationPtr>(shared_library_.get_function_pointer("niFgen_InitiateGeneration"));
   function_pointers_.InvalidateAllAttributes = reinterpret_cast<InvalidateAllAttributesPtr>(shared_library_.get_function_pointer("niFgen_InvalidateAllAttributes"));
   function_pointers_.IsDone = reinterpret_cast<IsDonePtr>(shared_library_.get_function_pointer("niFgen_IsDone"));
@@ -135,7 +126,6 @@ NiFgenLibrary::NiFgenLibrary() : shared_library_(kLibraryName)
   function_pointers_.QueryArbSeqCapabilities = reinterpret_cast<QueryArbSeqCapabilitiesPtr>(shared_library_.get_function_pointer("niFgen_QueryArbSeqCapabilities"));
   function_pointers_.QueryArbWfmCapabilities = reinterpret_cast<QueryArbWfmCapabilitiesPtr>(shared_library_.get_function_pointer("niFgen_QueryArbWfmCapabilities"));
   function_pointers_.QueryFreqListCapabilities = reinterpret_cast<QueryFreqListCapabilitiesPtr>(shared_library_.get_function_pointer("niFgen_QueryFreqListCapabilities"));
-  function_pointers_.ReadCalADC = reinterpret_cast<ReadCalADCPtr>(shared_library_.get_function_pointer("niFgen_ReadCalADC"));
   function_pointers_.ReadCurrentTemperature = reinterpret_cast<ReadCurrentTemperaturePtr>(shared_library_.get_function_pointer("niFgen_ReadCurrentTemperature"));
   function_pointers_.Reset = reinterpret_cast<ResetPtr>(shared_library_.get_function_pointer("niFgen_reset"));
   function_pointers_.ResetAttribute = reinterpret_cast<ResetAttributePtr>(shared_library_.get_function_pointer("niFgen_ResetAttribute"));
@@ -159,7 +149,6 @@ NiFgenLibrary::NiFgenLibrary() : shared_library_(kLibraryName)
   function_pointers_.SetWaveformNextWritePosition = reinterpret_cast<SetWaveformNextWritePositionPtr>(shared_library_.get_function_pointer("niFgen_SetWaveformNextWritePosition"));
   function_pointers_.UnlockSession = reinterpret_cast<UnlockSessionPtr>(shared_library_.get_function_pointer("niFgen_UnlockSession"));
   function_pointers_.WaitUntilDone = reinterpret_cast<WaitUntilDonePtr>(shared_library_.get_function_pointer("niFgen_WaitUntilDone"));
-  function_pointers_.WriteBinary16AnalogStaticValue = reinterpret_cast<WriteBinary16AnalogStaticValuePtr>(shared_library_.get_function_pointer("niFgen_WriteBinary16AnalogStaticValue"));
   function_pointers_.WriteBinary16Waveform = reinterpret_cast<WriteBinary16WaveformPtr>(shared_library_.get_function_pointer("niFgen_WriteBinary16Waveform"));
   function_pointers_.WriteComplexBinary16Waveform = reinterpret_cast<WriteComplexBinary16WaveformPtr>(shared_library_.get_function_pointer("niFgen_WriteComplexBinary16Waveform"));
   function_pointers_.WriteNamedWaveformF64 = reinterpret_cast<WriteNamedWaveformF64Ptr>(shared_library_.get_function_pointer("niFgen_WriteNamedWaveformF64"));
@@ -228,42 +217,6 @@ ViStatus NiFgenLibrary::AllocateWaveform(ViSession vi, ViConstString channelName
   return niFgen_AllocateWaveform(vi, channelName, waveformSize, waveformHandle);
 #else
   return function_pointers_.AllocateWaveform(vi, channelName, waveformSize, waveformHandle);
-#endif
-}
-
-ViStatus NiFgenLibrary::CalAdjustDirectPathOutputImpedance(ViSession vi, ViConstString channelName, ViInt32 configuration, ViReal64 loadImpedance, ViReal64 measuredSourceVoltage, ViReal64 measuredVoltageAcrossLoad)
-{
-  if (!function_pointers_.CalAdjustDirectPathOutputImpedance) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_CalAdjustDirectPathOutputImpedance.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_CalAdjustDirectPathOutputImpedance(vi, channelName, configuration, loadImpedance, measuredSourceVoltage, measuredVoltageAcrossLoad);
-#else
-  return function_pointers_.CalAdjustDirectPathOutputImpedance(vi, channelName, configuration, loadImpedance, measuredSourceVoltage, measuredVoltageAcrossLoad);
-#endif
-}
-
-ViStatus NiFgenLibrary::CalAdjustMainPathOutputImpedance(ViSession vi, ViConstString channelName, ViInt32 configuration, ViReal64 loadImpedance, ViReal64 measuredSourceVoltage, ViReal64 measuredVoltageAcrossLoad)
-{
-  if (!function_pointers_.CalAdjustMainPathOutputImpedance) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_CalAdjustMainPathOutputImpedance.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_CalAdjustMainPathOutputImpedance(vi, channelName, configuration, loadImpedance, measuredSourceVoltage, measuredVoltageAcrossLoad);
-#else
-  return function_pointers_.CalAdjustMainPathOutputImpedance(vi, channelName, configuration, loadImpedance, measuredSourceVoltage, measuredVoltageAcrossLoad);
-#endif
-}
-
-ViStatus NiFgenLibrary::CalAdjustOscillatorFrequency(ViSession vi, ViReal64 desiredFrequency, ViReal64 measuredFrequency)
-{
-  if (!function_pointers_.CalAdjustOscillatorFrequency) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_CalAdjustOscillatorFrequency.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_CalAdjustOscillatorFrequency(vi, desiredFrequency, measuredFrequency);
-#else
-  return function_pointers_.CalAdjustOscillatorFrequency(vi, desiredFrequency, measuredFrequency);
 #endif
 }
 
@@ -444,18 +397,6 @@ ViStatus NiFgenLibrary::Close(ViSession vi)
   return niFgen_close(vi);
 #else
   return function_pointers_.Close(vi);
-#endif
-}
-
-ViStatus NiFgenLibrary::CloseExtCal(ViSession vi, ViInt32 action)
-{
-  if (!function_pointers_.CloseExtCal) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_CloseExtCal.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_CloseExtCal(vi, action);
-#else
-  return function_pointers_.CloseExtCal(vi, action);
 #endif
 }
 
@@ -1371,18 +1312,6 @@ ViStatus NiFgenLibrary::Init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean r
 #endif
 }
 
-ViStatus NiFgenLibrary::InitExtCal(ViRsrc resourceName, ViConstString password, ViSession* vi)
-{
-  if (!function_pointers_.InitExtCal) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_InitExtCal.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_InitExtCal(resourceName, password, vi);
-#else
-  return function_pointers_.InitExtCal(resourceName, password, vi);
-#endif
-}
-
 ViStatus NiFgenLibrary::InitWithOptions(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi)
 {
   if (!function_pointers_.InitWithOptions) {
@@ -1404,54 +1333,6 @@ ViStatus NiFgenLibrary::InitializeWithChannels(ViRsrc resourceName, ViConstStrin
   return niFgen_InitializeWithChannels(resourceName, channelName, resetDevice, optionString, vi);
 #else
   return function_pointers_.InitializeWithChannels(resourceName, channelName, resetDevice, optionString, vi);
-#endif
-}
-
-ViStatus NiFgenLibrary::InitializeAnalogOutputCalibration(ViSession vi)
-{
-  if (!function_pointers_.InitializeAnalogOutputCalibration) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_InitializeAnalogOutputCalibration.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_InitializeAnalogOutputCalibration(vi);
-#else
-  return function_pointers_.InitializeAnalogOutputCalibration(vi);
-#endif
-}
-
-ViStatus NiFgenLibrary::InitializeCalADCCalibration(ViSession vi)
-{
-  if (!function_pointers_.InitializeCalADCCalibration) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_InitializeCalADCCalibration.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_InitializeCalADCCalibration(vi);
-#else
-  return function_pointers_.InitializeCalADCCalibration(vi);
-#endif
-}
-
-ViStatus NiFgenLibrary::InitializeFlatnessCalibration(ViSession vi)
-{
-  if (!function_pointers_.InitializeFlatnessCalibration) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_InitializeFlatnessCalibration.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_InitializeFlatnessCalibration(vi);
-#else
-  return function_pointers_.InitializeFlatnessCalibration(vi);
-#endif
-}
-
-ViStatus NiFgenLibrary::InitializeOscillatorFrequencyCalibration(ViSession vi)
-{
-  if (!function_pointers_.InitializeOscillatorFrequencyCalibration) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_InitializeOscillatorFrequencyCalibration.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_InitializeOscillatorFrequencyCalibration(vi);
-#else
-  return function_pointers_.InitializeOscillatorFrequencyCalibration(vi);
 #endif
 }
 
@@ -1548,18 +1429,6 @@ ViStatus NiFgenLibrary::QueryFreqListCapabilities(ViSession vi, ViInt32* maximum
   return niFgen_QueryFreqListCapabilities(vi, maximumNumberOfFreqLists, minimumFrequencyListLength, maximumFrequencyListLength, minimumFrequencyListDuration, maximumFrequencyListDuration, frequencyListDurationQuantum);
 #else
   return function_pointers_.QueryFreqListCapabilities(vi, maximumNumberOfFreqLists, minimumFrequencyListLength, maximumFrequencyListLength, minimumFrequencyListDuration, maximumFrequencyListDuration, frequencyListDurationQuantum);
-#endif
-}
-
-ViStatus NiFgenLibrary::ReadCalADC(ViSession vi, ViInt32 numberOfReadsToAverage, ViBoolean returnCalibratedValue, ViReal64* calAdcValue)
-{
-  if (!function_pointers_.ReadCalADC) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_ReadCalADC.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_ReadCalADC(vi, numberOfReadsToAverage, returnCalibratedValue, calAdcValue);
-#else
-  return function_pointers_.ReadCalADC(vi, numberOfReadsToAverage, returnCalibratedValue, calAdcValue);
 #endif
 }
 
@@ -1836,18 +1705,6 @@ ViStatus NiFgenLibrary::WaitUntilDone(ViSession vi, ViInt32 maxTime)
   return niFgen_WaitUntilDone(vi, maxTime);
 #else
   return function_pointers_.WaitUntilDone(vi, maxTime);
-#endif
-}
-
-ViStatus NiFgenLibrary::WriteBinary16AnalogStaticValue(ViSession vi, ViConstString channelName, ViInt16 value)
-{
-  if (!function_pointers_.WriteBinary16AnalogStaticValue) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_WriteBinary16AnalogStaticValue.");
-  }
-#if defined(_MSC_VER)
-  return niFgen_WriteBinary16AnalogStaticValue(vi, channelName, value);
-#else
-  return function_pointers_.WriteBinary16AnalogStaticValue(vi, channelName, value);
 #endif
 }
 

--- a/generated/nifgen/nifgen_library.h
+++ b/generated/nifgen/nifgen_library.h
@@ -68,7 +68,7 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus CreateWaveformComplexF64(ViSession vi, ViConstString channelName, ViInt32 numberOfSamples, NIComplexNumber_struct waveformDataArray[], ViInt32* waveformHandle);
   ViStatus CreateWaveformF64(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[], ViInt32* waveformHandle);
   ViStatus CreateWaveformFromFileF64(ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle);
-  ViStatus CreateWaveformFromFileHWS(ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle);
+  ViStatus CreateWaveformFromFileHws(ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle);
   ViStatus CreateWaveformI16(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViInt16 waveformDataArray[], ViInt32* waveformHandle);
   ViStatus CreateWaveformFromFileI16(ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle);
   ViStatus DefineUserStandardWaveform(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[]);
@@ -208,7 +208,7 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using CreateWaveformComplexF64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 numberOfSamples, NIComplexNumber_struct waveformDataArray[], ViInt32* waveformHandle);
   using CreateWaveformF64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[], ViInt32* waveformHandle);
   using CreateWaveformFromFileF64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle);
-  using CreateWaveformFromFileHWSPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle);
+  using CreateWaveformFromFileHwsPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle);
   using CreateWaveformI16Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViInt16 waveformDataArray[], ViInt32* waveformHandle);
   using CreateWaveformFromFileI16Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle);
   using DefineUserStandardWaveformPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[]);
@@ -348,7 +348,7 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
     CreateWaveformComplexF64Ptr CreateWaveformComplexF64;
     CreateWaveformF64Ptr CreateWaveformF64;
     CreateWaveformFromFileF64Ptr CreateWaveformFromFileF64;
-    CreateWaveformFromFileHWSPtr CreateWaveformFromFileHWS;
+    CreateWaveformFromFileHwsPtr CreateWaveformFromFileHws;
     CreateWaveformI16Ptr CreateWaveformI16;
     CreateWaveformFromFileI16Ptr CreateWaveformFromFileI16;
     DefineUserStandardWaveformPtr DefineUserStandardWaveform;

--- a/generated/nifgen/nifgen_library.h
+++ b/generated/nifgen/nifgen_library.h
@@ -22,9 +22,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus AdjustSampleClockRelativeDelay(ViSession vi, ViReal64 adjustmentTime);
   ViStatus AllocateNamedWaveform(ViSession vi, ViConstString channelName, ViConstString waveformName, ViInt32 waveformSize);
   ViStatus AllocateWaveform(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViInt32* waveformHandle);
-  ViStatus CalAdjustDirectPathOutputImpedance(ViSession vi, ViConstString channelName, ViInt32 configuration, ViReal64 loadImpedance, ViReal64 measuredSourceVoltage, ViReal64 measuredVoltageAcrossLoad);
-  ViStatus CalAdjustMainPathOutputImpedance(ViSession vi, ViConstString channelName, ViInt32 configuration, ViReal64 loadImpedance, ViReal64 measuredSourceVoltage, ViReal64 measuredVoltageAcrossLoad);
-  ViStatus CalAdjustOscillatorFrequency(ViSession vi, ViReal64 desiredFrequency, ViReal64 measuredFrequency);
   ViStatus ChangeExtCalPassword(ViSession vi, ViConstString oldPassword, ViConstString newPassword);
   ViStatus CheckAttributeViBoolean(ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue);
   ViStatus CheckAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue);
@@ -40,7 +37,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus ClearInterchangeWarnings(ViSession vi);
   ViStatus ClearUserStandardWaveform(ViSession vi, ViConstString channelName);
   ViStatus Close(ViSession vi);
-  ViStatus CloseExtCal(ViSession vi, ViInt32 action);
   ViStatus Commit(ViSession vi);
   ViStatus ConfigureAmplitude(ViSession vi, ViConstString channelName, ViReal64 amplitude);
   ViStatus ConfigureArbSequence(ViSession vi, ViConstString channelName, ViInt32 sequenceHandle, ViReal64 gain, ViReal64 offset);
@@ -72,7 +68,7 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus CreateWaveformComplexF64(ViSession vi, ViConstString channelName, ViInt32 numberOfSamples, NIComplexNumber_struct waveformDataArray[], ViInt32* waveformHandle);
   ViStatus CreateWaveformF64(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[], ViInt32* waveformHandle);
   ViStatus CreateWaveformFromFileF64(ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle);
-  ViStatus CreateWaveformFromFileHws(ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle);
+  ViStatus CreateWaveformFromFileHWS(ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle);
   ViStatus CreateWaveformI16(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViInt16 waveformDataArray[], ViInt32* waveformHandle);
   ViStatus CreateWaveformFromFileI16(ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle);
   ViStatus DefineUserStandardWaveform(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[]);
@@ -117,13 +113,8 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus ImportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViAddr configuration[]);
   ViStatus ImportAttributeConfigurationFile(ViSession vi, ViConstString filePath);
   ViStatus Init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi);
-  ViStatus InitExtCal(ViRsrc resourceName, ViConstString password, ViSession* vi);
   ViStatus InitWithOptions(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi);
   ViStatus InitializeWithChannels(ViRsrc resourceName, ViConstString channelName, ViBoolean resetDevice, ViConstString optionString, ViSession* vi);
-  ViStatus InitializeAnalogOutputCalibration(ViSession vi);
-  ViStatus InitializeCalADCCalibration(ViSession vi);
-  ViStatus InitializeFlatnessCalibration(ViSession vi);
-  ViStatus InitializeOscillatorFrequencyCalibration(ViSession vi);
   ViStatus InitiateGeneration(ViSession vi);
   ViStatus InvalidateAllAttributes(ViSession vi);
   ViStatus IsDone(ViSession vi, ViBoolean* done);
@@ -132,7 +123,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus QueryArbSeqCapabilities(ViSession vi, ViInt32* maximumNumberOfSequences, ViInt32* minimumSequenceLength, ViInt32* maximumSequenceLength, ViInt32* maximumLoopCount);
   ViStatus QueryArbWfmCapabilities(ViSession vi, ViInt32* maximumNumberOfWaveforms, ViInt32* waveformQuantum, ViInt32* minimumWaveformSize, ViInt32* maximumWaveformSize);
   ViStatus QueryFreqListCapabilities(ViSession vi, ViInt32* maximumNumberOfFreqLists, ViInt32* minimumFrequencyListLength, ViInt32* maximumFrequencyListLength, ViReal64* minimumFrequencyListDuration, ViReal64* maximumFrequencyListDuration, ViReal64* frequencyListDurationQuantum);
-  ViStatus ReadCalADC(ViSession vi, ViInt32 numberOfReadsToAverage, ViBoolean returnCalibratedValue, ViReal64* calAdcValue);
   ViStatus ReadCurrentTemperature(ViSession vi, ViReal64* temperature);
   ViStatus Reset(ViSession vi);
   ViStatus ResetAttribute(ViSession vi, ViConstString channelName, ViAttr attributeId);
@@ -156,7 +146,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus SetWaveformNextWritePosition(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 relativeTo, ViInt32 offset);
   ViStatus UnlockSession(ViSession vi, ViBoolean* callerHasLock);
   ViStatus WaitUntilDone(ViSession vi, ViInt32 maxTime);
-  ViStatus WriteBinary16AnalogStaticValue(ViSession vi, ViConstString channelName, ViInt16 value);
   ViStatus WriteBinary16Waveform(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 size, ViInt16 data[]);
   ViStatus WriteComplexBinary16Waveform(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 size, NIComplexI16_struct data[]);
   ViStatus WriteNamedWaveformF64(ViSession vi, ViConstString channelName, ViConstString waveformName, ViInt32 size, ViReal64 data[]);
@@ -173,9 +162,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using AdjustSampleClockRelativeDelayPtr = ViStatus (*)(ViSession vi, ViReal64 adjustmentTime);
   using AllocateNamedWaveformPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViConstString waveformName, ViInt32 waveformSize);
   using AllocateWaveformPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViInt32* waveformHandle);
-  using CalAdjustDirectPathOutputImpedancePtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 configuration, ViReal64 loadImpedance, ViReal64 measuredSourceVoltage, ViReal64 measuredVoltageAcrossLoad);
-  using CalAdjustMainPathOutputImpedancePtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 configuration, ViReal64 loadImpedance, ViReal64 measuredSourceVoltage, ViReal64 measuredVoltageAcrossLoad);
-  using CalAdjustOscillatorFrequencyPtr = ViStatus (*)(ViSession vi, ViReal64 desiredFrequency, ViReal64 measuredFrequency);
   using ChangeExtCalPasswordPtr = ViStatus (*)(ViSession vi, ViConstString oldPassword, ViConstString newPassword);
   using CheckAttributeViBooleanPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue);
   using CheckAttributeViInt32Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue);
@@ -191,7 +177,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using ClearInterchangeWarningsPtr = ViStatus (*)(ViSession vi);
   using ClearUserStandardWaveformPtr = ViStatus (*)(ViSession vi, ViConstString channelName);
   using ClosePtr = ViStatus (*)(ViSession vi);
-  using CloseExtCalPtr = ViStatus (*)(ViSession vi, ViInt32 action);
   using CommitPtr = ViStatus (*)(ViSession vi);
   using ConfigureAmplitudePtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViReal64 amplitude);
   using ConfigureArbSequencePtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 sequenceHandle, ViReal64 gain, ViReal64 offset);
@@ -223,7 +208,7 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using CreateWaveformComplexF64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 numberOfSamples, NIComplexNumber_struct waveformDataArray[], ViInt32* waveformHandle);
   using CreateWaveformF64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[], ViInt32* waveformHandle);
   using CreateWaveformFromFileF64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle);
-  using CreateWaveformFromFileHwsPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle);
+  using CreateWaveformFromFileHWSPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle);
   using CreateWaveformI16Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViInt16 waveformDataArray[], ViInt32* waveformHandle);
   using CreateWaveformFromFileI16Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle);
   using DefineUserStandardWaveformPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[]);
@@ -268,13 +253,8 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using ImportAttributeConfigurationBufferPtr = ViStatus (*)(ViSession vi, ViInt32 sizeInBytes, ViAddr configuration[]);
   using ImportAttributeConfigurationFilePtr = ViStatus (*)(ViSession vi, ViConstString filePath);
   using InitPtr = ViStatus (*)(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi);
-  using InitExtCalPtr = ViStatus (*)(ViRsrc resourceName, ViConstString password, ViSession* vi);
   using InitWithOptionsPtr = ViStatus (*)(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi);
   using InitializeWithChannelsPtr = ViStatus (*)(ViRsrc resourceName, ViConstString channelName, ViBoolean resetDevice, ViConstString optionString, ViSession* vi);
-  using InitializeAnalogOutputCalibrationPtr = ViStatus (*)(ViSession vi);
-  using InitializeCalADCCalibrationPtr = ViStatus (*)(ViSession vi);
-  using InitializeFlatnessCalibrationPtr = ViStatus (*)(ViSession vi);
-  using InitializeOscillatorFrequencyCalibrationPtr = ViStatus (*)(ViSession vi);
   using InitiateGenerationPtr = ViStatus (*)(ViSession vi);
   using InvalidateAllAttributesPtr = ViStatus (*)(ViSession vi);
   using IsDonePtr = ViStatus (*)(ViSession vi, ViBoolean* done);
@@ -283,7 +263,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using QueryArbSeqCapabilitiesPtr = ViStatus (*)(ViSession vi, ViInt32* maximumNumberOfSequences, ViInt32* minimumSequenceLength, ViInt32* maximumSequenceLength, ViInt32* maximumLoopCount);
   using QueryArbWfmCapabilitiesPtr = ViStatus (*)(ViSession vi, ViInt32* maximumNumberOfWaveforms, ViInt32* waveformQuantum, ViInt32* minimumWaveformSize, ViInt32* maximumWaveformSize);
   using QueryFreqListCapabilitiesPtr = ViStatus (*)(ViSession vi, ViInt32* maximumNumberOfFreqLists, ViInt32* minimumFrequencyListLength, ViInt32* maximumFrequencyListLength, ViReal64* minimumFrequencyListDuration, ViReal64* maximumFrequencyListDuration, ViReal64* frequencyListDurationQuantum);
-  using ReadCalADCPtr = ViStatus (*)(ViSession vi, ViInt32 numberOfReadsToAverage, ViBoolean returnCalibratedValue, ViReal64* calAdcValue);
   using ReadCurrentTemperaturePtr = ViStatus (*)(ViSession vi, ViReal64* temperature);
   using ResetPtr = ViStatus (*)(ViSession vi);
   using ResetAttributePtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId);
@@ -307,7 +286,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using SetWaveformNextWritePositionPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 relativeTo, ViInt32 offset);
   using UnlockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using WaitUntilDonePtr = ViStatus (*)(ViSession vi, ViInt32 maxTime);
-  using WriteBinary16AnalogStaticValuePtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt16 value);
   using WriteBinary16WaveformPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 size, ViInt16 data[]);
   using WriteComplexBinary16WaveformPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 size, NIComplexI16_struct data[]);
   using WriteNamedWaveformF64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViConstString waveformName, ViInt32 size, ViReal64 data[]);
@@ -324,9 +302,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
     AdjustSampleClockRelativeDelayPtr AdjustSampleClockRelativeDelay;
     AllocateNamedWaveformPtr AllocateNamedWaveform;
     AllocateWaveformPtr AllocateWaveform;
-    CalAdjustDirectPathOutputImpedancePtr CalAdjustDirectPathOutputImpedance;
-    CalAdjustMainPathOutputImpedancePtr CalAdjustMainPathOutputImpedance;
-    CalAdjustOscillatorFrequencyPtr CalAdjustOscillatorFrequency;
     ChangeExtCalPasswordPtr ChangeExtCalPassword;
     CheckAttributeViBooleanPtr CheckAttributeViBoolean;
     CheckAttributeViInt32Ptr CheckAttributeViInt32;
@@ -342,7 +317,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
     ClearInterchangeWarningsPtr ClearInterchangeWarnings;
     ClearUserStandardWaveformPtr ClearUserStandardWaveform;
     ClosePtr Close;
-    CloseExtCalPtr CloseExtCal;
     CommitPtr Commit;
     ConfigureAmplitudePtr ConfigureAmplitude;
     ConfigureArbSequencePtr ConfigureArbSequence;
@@ -374,7 +348,7 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
     CreateWaveformComplexF64Ptr CreateWaveformComplexF64;
     CreateWaveformF64Ptr CreateWaveformF64;
     CreateWaveformFromFileF64Ptr CreateWaveformFromFileF64;
-    CreateWaveformFromFileHwsPtr CreateWaveformFromFileHws;
+    CreateWaveformFromFileHWSPtr CreateWaveformFromFileHWS;
     CreateWaveformI16Ptr CreateWaveformI16;
     CreateWaveformFromFileI16Ptr CreateWaveformFromFileI16;
     DefineUserStandardWaveformPtr DefineUserStandardWaveform;
@@ -419,13 +393,8 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
     ImportAttributeConfigurationBufferPtr ImportAttributeConfigurationBuffer;
     ImportAttributeConfigurationFilePtr ImportAttributeConfigurationFile;
     InitPtr Init;
-    InitExtCalPtr InitExtCal;
     InitWithOptionsPtr InitWithOptions;
     InitializeWithChannelsPtr InitializeWithChannels;
-    InitializeAnalogOutputCalibrationPtr InitializeAnalogOutputCalibration;
-    InitializeCalADCCalibrationPtr InitializeCalADCCalibration;
-    InitializeFlatnessCalibrationPtr InitializeFlatnessCalibration;
-    InitializeOscillatorFrequencyCalibrationPtr InitializeOscillatorFrequencyCalibration;
     InitiateGenerationPtr InitiateGeneration;
     InvalidateAllAttributesPtr InvalidateAllAttributes;
     IsDonePtr IsDone;
@@ -434,7 +403,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
     QueryArbSeqCapabilitiesPtr QueryArbSeqCapabilities;
     QueryArbWfmCapabilitiesPtr QueryArbWfmCapabilities;
     QueryFreqListCapabilitiesPtr QueryFreqListCapabilities;
-    ReadCalADCPtr ReadCalADC;
     ReadCurrentTemperaturePtr ReadCurrentTemperature;
     ResetPtr Reset;
     ResetAttributePtr ResetAttribute;
@@ -458,7 +426,6 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
     SetWaveformNextWritePositionPtr SetWaveformNextWritePosition;
     UnlockSessionPtr UnlockSession;
     WaitUntilDonePtr WaitUntilDone;
-    WriteBinary16AnalogStaticValuePtr WriteBinary16AnalogStaticValue;
     WriteBinary16WaveformPtr WriteBinary16Waveform;
     WriteComplexBinary16WaveformPtr WriteComplexBinary16Waveform;
     WriteNamedWaveformF64Ptr WriteNamedWaveformF64;

--- a/generated/nifgen/nifgen_library_interface.h
+++ b/generated/nifgen/nifgen_library_interface.h
@@ -65,7 +65,7 @@ class NiFgenLibraryInterface {
   virtual ViStatus CreateWaveformComplexF64(ViSession vi, ViConstString channelName, ViInt32 numberOfSamples, NIComplexNumber_struct waveformDataArray[], ViInt32* waveformHandle) = 0;
   virtual ViStatus CreateWaveformF64(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[], ViInt32* waveformHandle) = 0;
   virtual ViStatus CreateWaveformFromFileF64(ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle) = 0;
-  virtual ViStatus CreateWaveformFromFileHWS(ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle) = 0;
+  virtual ViStatus CreateWaveformFromFileHws(ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle) = 0;
   virtual ViStatus CreateWaveformI16(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViInt16 waveformDataArray[], ViInt32* waveformHandle) = 0;
   virtual ViStatus CreateWaveformFromFileI16(ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle) = 0;
   virtual ViStatus DefineUserStandardWaveform(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[]) = 0;

--- a/generated/nifgen/nifgen_library_interface.h
+++ b/generated/nifgen/nifgen_library_interface.h
@@ -19,9 +19,6 @@ class NiFgenLibraryInterface {
   virtual ViStatus AdjustSampleClockRelativeDelay(ViSession vi, ViReal64 adjustmentTime) = 0;
   virtual ViStatus AllocateNamedWaveform(ViSession vi, ViConstString channelName, ViConstString waveformName, ViInt32 waveformSize) = 0;
   virtual ViStatus AllocateWaveform(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViInt32* waveformHandle) = 0;
-  virtual ViStatus CalAdjustDirectPathOutputImpedance(ViSession vi, ViConstString channelName, ViInt32 configuration, ViReal64 loadImpedance, ViReal64 measuredSourceVoltage, ViReal64 measuredVoltageAcrossLoad) = 0;
-  virtual ViStatus CalAdjustMainPathOutputImpedance(ViSession vi, ViConstString channelName, ViInt32 configuration, ViReal64 loadImpedance, ViReal64 measuredSourceVoltage, ViReal64 measuredVoltageAcrossLoad) = 0;
-  virtual ViStatus CalAdjustOscillatorFrequency(ViSession vi, ViReal64 desiredFrequency, ViReal64 measuredFrequency) = 0;
   virtual ViStatus ChangeExtCalPassword(ViSession vi, ViConstString oldPassword, ViConstString newPassword) = 0;
   virtual ViStatus CheckAttributeViBoolean(ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue) = 0;
   virtual ViStatus CheckAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue) = 0;
@@ -37,7 +34,6 @@ class NiFgenLibraryInterface {
   virtual ViStatus ClearInterchangeWarnings(ViSession vi) = 0;
   virtual ViStatus ClearUserStandardWaveform(ViSession vi, ViConstString channelName) = 0;
   virtual ViStatus Close(ViSession vi) = 0;
-  virtual ViStatus CloseExtCal(ViSession vi, ViInt32 action) = 0;
   virtual ViStatus Commit(ViSession vi) = 0;
   virtual ViStatus ConfigureAmplitude(ViSession vi, ViConstString channelName, ViReal64 amplitude) = 0;
   virtual ViStatus ConfigureArbSequence(ViSession vi, ViConstString channelName, ViInt32 sequenceHandle, ViReal64 gain, ViReal64 offset) = 0;
@@ -69,7 +65,7 @@ class NiFgenLibraryInterface {
   virtual ViStatus CreateWaveformComplexF64(ViSession vi, ViConstString channelName, ViInt32 numberOfSamples, NIComplexNumber_struct waveformDataArray[], ViInt32* waveformHandle) = 0;
   virtual ViStatus CreateWaveformF64(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[], ViInt32* waveformHandle) = 0;
   virtual ViStatus CreateWaveformFromFileF64(ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle) = 0;
-  virtual ViStatus CreateWaveformFromFileHws(ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle) = 0;
+  virtual ViStatus CreateWaveformFromFileHWS(ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle) = 0;
   virtual ViStatus CreateWaveformI16(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViInt16 waveformDataArray[], ViInt32* waveformHandle) = 0;
   virtual ViStatus CreateWaveformFromFileI16(ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle) = 0;
   virtual ViStatus DefineUserStandardWaveform(ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[]) = 0;
@@ -114,13 +110,8 @@ class NiFgenLibraryInterface {
   virtual ViStatus ImportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViAddr configuration[]) = 0;
   virtual ViStatus ImportAttributeConfigurationFile(ViSession vi, ViConstString filePath) = 0;
   virtual ViStatus Init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi) = 0;
-  virtual ViStatus InitExtCal(ViRsrc resourceName, ViConstString password, ViSession* vi) = 0;
   virtual ViStatus InitWithOptions(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi) = 0;
   virtual ViStatus InitializeWithChannels(ViRsrc resourceName, ViConstString channelName, ViBoolean resetDevice, ViConstString optionString, ViSession* vi) = 0;
-  virtual ViStatus InitializeAnalogOutputCalibration(ViSession vi) = 0;
-  virtual ViStatus InitializeCalADCCalibration(ViSession vi) = 0;
-  virtual ViStatus InitializeFlatnessCalibration(ViSession vi) = 0;
-  virtual ViStatus InitializeOscillatorFrequencyCalibration(ViSession vi) = 0;
   virtual ViStatus InitiateGeneration(ViSession vi) = 0;
   virtual ViStatus InvalidateAllAttributes(ViSession vi) = 0;
   virtual ViStatus IsDone(ViSession vi, ViBoolean* done) = 0;
@@ -129,7 +120,6 @@ class NiFgenLibraryInterface {
   virtual ViStatus QueryArbSeqCapabilities(ViSession vi, ViInt32* maximumNumberOfSequences, ViInt32* minimumSequenceLength, ViInt32* maximumSequenceLength, ViInt32* maximumLoopCount) = 0;
   virtual ViStatus QueryArbWfmCapabilities(ViSession vi, ViInt32* maximumNumberOfWaveforms, ViInt32* waveformQuantum, ViInt32* minimumWaveformSize, ViInt32* maximumWaveformSize) = 0;
   virtual ViStatus QueryFreqListCapabilities(ViSession vi, ViInt32* maximumNumberOfFreqLists, ViInt32* minimumFrequencyListLength, ViInt32* maximumFrequencyListLength, ViReal64* minimumFrequencyListDuration, ViReal64* maximumFrequencyListDuration, ViReal64* frequencyListDurationQuantum) = 0;
-  virtual ViStatus ReadCalADC(ViSession vi, ViInt32 numberOfReadsToAverage, ViBoolean returnCalibratedValue, ViReal64* calAdcValue) = 0;
   virtual ViStatus ReadCurrentTemperature(ViSession vi, ViReal64* temperature) = 0;
   virtual ViStatus Reset(ViSession vi) = 0;
   virtual ViStatus ResetAttribute(ViSession vi, ViConstString channelName, ViAttr attributeId) = 0;
@@ -153,7 +143,6 @@ class NiFgenLibraryInterface {
   virtual ViStatus SetWaveformNextWritePosition(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 relativeTo, ViInt32 offset) = 0;
   virtual ViStatus UnlockSession(ViSession vi, ViBoolean* callerHasLock) = 0;
   virtual ViStatus WaitUntilDone(ViSession vi, ViInt32 maxTime) = 0;
-  virtual ViStatus WriteBinary16AnalogStaticValue(ViSession vi, ViConstString channelName, ViInt16 value) = 0;
   virtual ViStatus WriteBinary16Waveform(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 size, ViInt16 data[]) = 0;
   virtual ViStatus WriteComplexBinary16Waveform(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 size, NIComplexI16_struct data[]) = 0;
   virtual ViStatus WriteNamedWaveformF64(ViSession vi, ViConstString channelName, ViConstString waveformName, ViInt32 size, ViReal64 data[]) = 0;

--- a/generated/nifgen/nifgen_mock_library.h
+++ b/generated/nifgen/nifgen_mock_library.h
@@ -67,7 +67,7 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, CreateWaveformComplexF64, (ViSession vi, ViConstString channelName, ViInt32 numberOfSamples, NIComplexNumber_struct waveformDataArray[], ViInt32* waveformHandle), (override));
   MOCK_METHOD(ViStatus, CreateWaveformF64, (ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[], ViInt32* waveformHandle), (override));
   MOCK_METHOD(ViStatus, CreateWaveformFromFileF64, (ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle), (override));
-  MOCK_METHOD(ViStatus, CreateWaveformFromFileHWS, (ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle), (override));
+  MOCK_METHOD(ViStatus, CreateWaveformFromFileHws, (ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle), (override));
   MOCK_METHOD(ViStatus, CreateWaveformI16, (ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViInt16 waveformDataArray[], ViInt32* waveformHandle), (override));
   MOCK_METHOD(ViStatus, CreateWaveformFromFileI16, (ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle), (override));
   MOCK_METHOD(ViStatus, DefineUserStandardWaveform, (ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[]), (override));

--- a/generated/nifgen/nifgen_mock_library.h
+++ b/generated/nifgen/nifgen_mock_library.h
@@ -21,9 +21,6 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, AdjustSampleClockRelativeDelay, (ViSession vi, ViReal64 adjustmentTime), (override));
   MOCK_METHOD(ViStatus, AllocateNamedWaveform, (ViSession vi, ViConstString channelName, ViConstString waveformName, ViInt32 waveformSize), (override));
   MOCK_METHOD(ViStatus, AllocateWaveform, (ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViInt32* waveformHandle), (override));
-  MOCK_METHOD(ViStatus, CalAdjustDirectPathOutputImpedance, (ViSession vi, ViConstString channelName, ViInt32 configuration, ViReal64 loadImpedance, ViReal64 measuredSourceVoltage, ViReal64 measuredVoltageAcrossLoad), (override));
-  MOCK_METHOD(ViStatus, CalAdjustMainPathOutputImpedance, (ViSession vi, ViConstString channelName, ViInt32 configuration, ViReal64 loadImpedance, ViReal64 measuredSourceVoltage, ViReal64 measuredVoltageAcrossLoad), (override));
-  MOCK_METHOD(ViStatus, CalAdjustOscillatorFrequency, (ViSession vi, ViReal64 desiredFrequency, ViReal64 measuredFrequency), (override));
   MOCK_METHOD(ViStatus, ChangeExtCalPassword, (ViSession vi, ViConstString oldPassword, ViConstString newPassword), (override));
   MOCK_METHOD(ViStatus, CheckAttributeViBoolean, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue), (override));
   MOCK_METHOD(ViStatus, CheckAttributeViInt32, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue), (override));
@@ -39,7 +36,6 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, ClearInterchangeWarnings, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, ClearUserStandardWaveform, (ViSession vi, ViConstString channelName), (override));
   MOCK_METHOD(ViStatus, Close, (ViSession vi), (override));
-  MOCK_METHOD(ViStatus, CloseExtCal, (ViSession vi, ViInt32 action), (override));
   MOCK_METHOD(ViStatus, Commit, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, ConfigureAmplitude, (ViSession vi, ViConstString channelName, ViReal64 amplitude), (override));
   MOCK_METHOD(ViStatus, ConfigureArbSequence, (ViSession vi, ViConstString channelName, ViInt32 sequenceHandle, ViReal64 gain, ViReal64 offset), (override));
@@ -71,7 +67,7 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, CreateWaveformComplexF64, (ViSession vi, ViConstString channelName, ViInt32 numberOfSamples, NIComplexNumber_struct waveformDataArray[], ViInt32* waveformHandle), (override));
   MOCK_METHOD(ViStatus, CreateWaveformF64, (ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[], ViInt32* waveformHandle), (override));
   MOCK_METHOD(ViStatus, CreateWaveformFromFileF64, (ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle), (override));
-  MOCK_METHOD(ViStatus, CreateWaveformFromFileHws, (ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle), (override));
+  MOCK_METHOD(ViStatus, CreateWaveformFromFileHWS, (ViSession vi, ViConstString channelName, ViConstString fileName, ViBoolean useRateFromWaveform, ViBoolean useGainAndOffsetFromWaveform, ViInt32* waveformHandle), (override));
   MOCK_METHOD(ViStatus, CreateWaveformI16, (ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViInt16 waveformDataArray[], ViInt32* waveformHandle), (override));
   MOCK_METHOD(ViStatus, CreateWaveformFromFileI16, (ViSession vi, ViConstString channelName, ViConstString fileName, ViInt32 byteOrder, ViInt32* waveformHandle), (override));
   MOCK_METHOD(ViStatus, DefineUserStandardWaveform, (ViSession vi, ViConstString channelName, ViInt32 waveformSize, ViReal64 waveformDataArray[]), (override));
@@ -116,13 +112,8 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, ImportAttributeConfigurationBuffer, (ViSession vi, ViInt32 sizeInBytes, ViAddr configuration[]), (override));
   MOCK_METHOD(ViStatus, ImportAttributeConfigurationFile, (ViSession vi, ViConstString filePath), (override));
   MOCK_METHOD(ViStatus, Init, (ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi), (override));
-  MOCK_METHOD(ViStatus, InitExtCal, (ViRsrc resourceName, ViConstString password, ViSession* vi), (override));
   MOCK_METHOD(ViStatus, InitWithOptions, (ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi), (override));
   MOCK_METHOD(ViStatus, InitializeWithChannels, (ViRsrc resourceName, ViConstString channelName, ViBoolean resetDevice, ViConstString optionString, ViSession* vi), (override));
-  MOCK_METHOD(ViStatus, InitializeAnalogOutputCalibration, (ViSession vi), (override));
-  MOCK_METHOD(ViStatus, InitializeCalADCCalibration, (ViSession vi), (override));
-  MOCK_METHOD(ViStatus, InitializeFlatnessCalibration, (ViSession vi), (override));
-  MOCK_METHOD(ViStatus, InitializeOscillatorFrequencyCalibration, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, InitiateGeneration, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, InvalidateAllAttributes, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, IsDone, (ViSession vi, ViBoolean* done), (override));
@@ -131,7 +122,6 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, QueryArbSeqCapabilities, (ViSession vi, ViInt32* maximumNumberOfSequences, ViInt32* minimumSequenceLength, ViInt32* maximumSequenceLength, ViInt32* maximumLoopCount), (override));
   MOCK_METHOD(ViStatus, QueryArbWfmCapabilities, (ViSession vi, ViInt32* maximumNumberOfWaveforms, ViInt32* waveformQuantum, ViInt32* minimumWaveformSize, ViInt32* maximumWaveformSize), (override));
   MOCK_METHOD(ViStatus, QueryFreqListCapabilities, (ViSession vi, ViInt32* maximumNumberOfFreqLists, ViInt32* minimumFrequencyListLength, ViInt32* maximumFrequencyListLength, ViReal64* minimumFrequencyListDuration, ViReal64* maximumFrequencyListDuration, ViReal64* frequencyListDurationQuantum), (override));
-  MOCK_METHOD(ViStatus, ReadCalADC, (ViSession vi, ViInt32 numberOfReadsToAverage, ViBoolean returnCalibratedValue, ViReal64* calAdcValue), (override));
   MOCK_METHOD(ViStatus, ReadCurrentTemperature, (ViSession vi, ViReal64* temperature), (override));
   MOCK_METHOD(ViStatus, Reset, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, ResetAttribute, (ViSession vi, ViConstString channelName, ViAttr attributeId), (override));
@@ -155,7 +145,6 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, SetWaveformNextWritePosition, (ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 relativeTo, ViInt32 offset), (override));
   MOCK_METHOD(ViStatus, UnlockSession, (ViSession vi, ViBoolean* callerHasLock), (override));
   MOCK_METHOD(ViStatus, WaitUntilDone, (ViSession vi, ViInt32 maxTime), (override));
-  MOCK_METHOD(ViStatus, WriteBinary16AnalogStaticValue, (ViSession vi, ViConstString channelName, ViInt16 value), (override));
   MOCK_METHOD(ViStatus, WriteBinary16Waveform, (ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 size, ViInt16 data[]), (override));
   MOCK_METHOD(ViStatus, WriteComplexBinary16Waveform, (ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 size, NIComplexI16_struct data[]), (override));
   MOCK_METHOD(ViStatus, WriteNamedWaveformF64, (ViSession vi, ViConstString channelName, ViConstString waveformName, ViInt32 size, ViReal64 data[]), (override));

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -145,75 +145,6 @@ namespace nifgen_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::CalAdjustDirectPathOutputImpedance(::grpc::ServerContext* context, const CalAdjustDirectPathOutputImpedanceRequest* request, CalAdjustDirectPathOutputImpedanceResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViConstString channel_name = request->channel_name().c_str();
-      ViInt32 configuration = request->configuration();
-      ViReal64 load_impedance = request->load_impedance();
-      ViReal64 measured_source_voltage = request->measured_source_voltage();
-      ViReal64 measured_voltage_across_load = request->measured_voltage_across_load();
-      auto status = library_->CalAdjustDirectPathOutputImpedance(vi, channel_name, configuration, load_impedance, measured_source_voltage, measured_voltage_across_load);
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::CalAdjustMainPathOutputImpedance(::grpc::ServerContext* context, const CalAdjustMainPathOutputImpedanceRequest* request, CalAdjustMainPathOutputImpedanceResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViConstString channel_name = request->channel_name().c_str();
-      ViInt32 configuration = request->configuration();
-      ViReal64 load_impedance = request->load_impedance();
-      ViReal64 measured_source_voltage = request->measured_source_voltage();
-      ViReal64 measured_voltage_across_load = request->measured_voltage_across_load();
-      auto status = library_->CalAdjustMainPathOutputImpedance(vi, channel_name, configuration, load_impedance, measured_source_voltage, measured_voltage_across_load);
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::CalAdjustOscillatorFrequency(::grpc::ServerContext* context, const CalAdjustOscillatorFrequencyRequest* request, CalAdjustOscillatorFrequencyResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViReal64 desired_frequency = request->desired_frequency();
-      ViReal64 measured_frequency = request->measured_frequency();
-      auto status = library_->CalAdjustOscillatorFrequency(vi, desired_frequency, measured_frequency);
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiFgenService::ChangeExtCalPassword(::grpc::ServerContext* context, const ChangeExtCalPasswordRequest* request, ChangeExtCalPasswordResponse* response)
   {
     if (context->IsCancelled()) {
@@ -515,27 +446,6 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       session_repository_->remove_session(vi);
       auto status = library_->Close(vi);
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::CloseExtCal(::grpc::ServerContext* context, const CloseExtCalRequest* request, CloseExtCalResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 action = request->action();
-      session_repository_->remove_session(vi);
-      auto status = library_->CloseExtCal(vi, action);
       response->set_status(status);
       return ::grpc::Status::OK;
     }
@@ -2375,37 +2285,6 @@ namespace nifgen_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::InitExtCal(::grpc::ServerContext* context, const InitExtCalRequest* request, InitExtCalResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      ViRsrc resource_name = (ViRsrc)request->resource_name().c_str();
-      ViConstString password = request->password().c_str();
-
-      auto init_lambda = [&] () -> std::tuple<int, uint32_t> {
-        ViSession vi;
-        int status = library_->InitExtCal(resource_name, password, &vi);
-        return std::make_tuple(status, vi);
-      };
-      uint32_t session_id = 0;
-      const std::string& session_name = request->session_name();
-      auto cleanup_lambda = [&] (uint32_t id) { library_->CloseExtCal(id, NIFGEN_VAL_EXT_CAL_ABORT); };
-      int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
-      response->set_status(status);
-      if (status == 0) {
-        response->mutable_vi()->set_id(session_id);
-      }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiFgenService::InitWithOptions(::grpc::ServerContext* context, const InitWithOptionsRequest* request, InitWithOptionsResponse* response)
   {
     if (context->IsCancelled()) {
@@ -2463,82 +2342,6 @@ namespace nifgen_grpc {
       if (status == 0) {
         response->mutable_vi()->set_id(session_id);
       }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::InitializeAnalogOutputCalibration(::grpc::ServerContext* context, const InitializeAnalogOutputCalibrationRequest* request, InitializeAnalogOutputCalibrationResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      auto status = library_->InitializeAnalogOutputCalibration(vi);
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::InitializeCalADCCalibration(::grpc::ServerContext* context, const InitializeCalADCCalibrationRequest* request, InitializeCalADCCalibrationResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      auto status = library_->InitializeCalADCCalibration(vi);
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::InitializeFlatnessCalibration(::grpc::ServerContext* context, const InitializeFlatnessCalibrationRequest* request, InitializeFlatnessCalibrationResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      auto status = library_->InitializeFlatnessCalibration(vi);
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::InitializeOscillatorFrequencyCalibration(::grpc::ServerContext* context, const InitializeOscillatorFrequencyCalibrationRequest* request, InitializeOscillatorFrequencyCalibrationResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      auto status = library_->InitializeOscillatorFrequencyCalibration(vi);
-      response->set_status(status);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -2733,31 +2536,6 @@ namespace nifgen_grpc {
         response->set_minimum_frequency_list_duration(minimum_frequency_list_duration);
         response->set_maximum_frequency_list_duration(maximum_frequency_list_duration);
         response->set_frequency_list_duration_quantum(frequency_list_duration_quantum);
-      }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::ReadCalADC(::grpc::ServerContext* context, const ReadCalADCRequest* request, ReadCalADCResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 number_of_reads_to_average = request->number_of_reads_to_average();
-      ViBoolean return_calibrated_value = request->return_calibrated_value();
-      ViReal64 cal_adc_value {};
-      auto status = library_->ReadCalADC(vi, number_of_reads_to_average, return_calibrated_value, &cal_adc_value);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_cal_adc_value(cal_adc_value);
       }
       return ::grpc::Status::OK;
     }
@@ -3287,27 +3065,6 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 max_time = request->max_time();
       auto status = library_->WaitUntilDone(vi, max_time);
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::WriteBinary16AnalogStaticValue(::grpc::ServerContext* context, const WriteBinary16AnalogStaticValueRequest* request, WriteBinary16AnalogStaticValueResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViConstString channel_name = request->channel_name().c_str();
-      ViInt16 value = (ViInt16)request->value();
-      auto status = library_->WriteBinary16AnalogStaticValue(vi, channel_name, value);
       response->set_status(status);
       return ::grpc::Status::OK;
     }

--- a/generated/nifgen/nifgen_service.h
+++ b/generated/nifgen/nifgen_service.h
@@ -74,7 +74,7 @@ public:
   ::grpc::Status CreateWaveformComplexF64(::grpc::ServerContext* context, const CreateWaveformComplexF64Request* request, CreateWaveformComplexF64Response* response) override;
   ::grpc::Status CreateWaveformF64(::grpc::ServerContext* context, const CreateWaveformF64Request* request, CreateWaveformF64Response* response) override;
   ::grpc::Status CreateWaveformFromFileF64(::grpc::ServerContext* context, const CreateWaveformFromFileF64Request* request, CreateWaveformFromFileF64Response* response) override;
-  ::grpc::Status CreateWaveformFromFileHWS(::grpc::ServerContext* context, const CreateWaveformFromFileHWSRequest* request, CreateWaveformFromFileHWSResponse* response) override;
+  ::grpc::Status CreateWaveformFromFileHws(::grpc::ServerContext* context, const CreateWaveformFromFileHwsRequest* request, CreateWaveformFromFileHwsResponse* response) override;
   ::grpc::Status CreateWaveformI16(::grpc::ServerContext* context, const CreateWaveformI16Request* request, CreateWaveformI16Response* response) override;
   ::grpc::Status CreateWaveformFromFileI16(::grpc::ServerContext* context, const CreateWaveformFromFileI16Request* request, CreateWaveformFromFileI16Response* response) override;
   ::grpc::Status DefineUserStandardWaveform(::grpc::ServerContext* context, const DefineUserStandardWaveformRequest* request, DefineUserStandardWaveformResponse* response) override;

--- a/generated/nifgen/nifgen_service.h
+++ b/generated/nifgen/nifgen_service.h
@@ -28,9 +28,6 @@ public:
   ::grpc::Status AdjustSampleClockRelativeDelay(::grpc::ServerContext* context, const AdjustSampleClockRelativeDelayRequest* request, AdjustSampleClockRelativeDelayResponse* response) override;
   ::grpc::Status AllocateNamedWaveform(::grpc::ServerContext* context, const AllocateNamedWaveformRequest* request, AllocateNamedWaveformResponse* response) override;
   ::grpc::Status AllocateWaveform(::grpc::ServerContext* context, const AllocateWaveformRequest* request, AllocateWaveformResponse* response) override;
-  ::grpc::Status CalAdjustDirectPathOutputImpedance(::grpc::ServerContext* context, const CalAdjustDirectPathOutputImpedanceRequest* request, CalAdjustDirectPathOutputImpedanceResponse* response) override;
-  ::grpc::Status CalAdjustMainPathOutputImpedance(::grpc::ServerContext* context, const CalAdjustMainPathOutputImpedanceRequest* request, CalAdjustMainPathOutputImpedanceResponse* response) override;
-  ::grpc::Status CalAdjustOscillatorFrequency(::grpc::ServerContext* context, const CalAdjustOscillatorFrequencyRequest* request, CalAdjustOscillatorFrequencyResponse* response) override;
   ::grpc::Status ChangeExtCalPassword(::grpc::ServerContext* context, const ChangeExtCalPasswordRequest* request, ChangeExtCalPasswordResponse* response) override;
   ::grpc::Status CheckAttributeViBoolean(::grpc::ServerContext* context, const CheckAttributeViBooleanRequest* request, CheckAttributeViBooleanResponse* response) override;
   ::grpc::Status CheckAttributeViInt32(::grpc::ServerContext* context, const CheckAttributeViInt32Request* request, CheckAttributeViInt32Response* response) override;
@@ -46,7 +43,6 @@ public:
   ::grpc::Status ClearInterchangeWarnings(::grpc::ServerContext* context, const ClearInterchangeWarningsRequest* request, ClearInterchangeWarningsResponse* response) override;
   ::grpc::Status ClearUserStandardWaveform(::grpc::ServerContext* context, const ClearUserStandardWaveformRequest* request, ClearUserStandardWaveformResponse* response) override;
   ::grpc::Status Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response) override;
-  ::grpc::Status CloseExtCal(::grpc::ServerContext* context, const CloseExtCalRequest* request, CloseExtCalResponse* response) override;
   ::grpc::Status Commit(::grpc::ServerContext* context, const CommitRequest* request, CommitResponse* response) override;
   ::grpc::Status ConfigureAmplitude(::grpc::ServerContext* context, const ConfigureAmplitudeRequest* request, ConfigureAmplitudeResponse* response) override;
   ::grpc::Status ConfigureArbSequence(::grpc::ServerContext* context, const ConfigureArbSequenceRequest* request, ConfigureArbSequenceResponse* response) override;
@@ -78,7 +74,7 @@ public:
   ::grpc::Status CreateWaveformComplexF64(::grpc::ServerContext* context, const CreateWaveformComplexF64Request* request, CreateWaveformComplexF64Response* response) override;
   ::grpc::Status CreateWaveformF64(::grpc::ServerContext* context, const CreateWaveformF64Request* request, CreateWaveformF64Response* response) override;
   ::grpc::Status CreateWaveformFromFileF64(::grpc::ServerContext* context, const CreateWaveformFromFileF64Request* request, CreateWaveformFromFileF64Response* response) override;
-  ::grpc::Status CreateWaveformFromFileHws(::grpc::ServerContext* context, const CreateWaveformFromFileHwsRequest* request, CreateWaveformFromFileHwsResponse* response) override;
+  ::grpc::Status CreateWaveformFromFileHWS(::grpc::ServerContext* context, const CreateWaveformFromFileHWSRequest* request, CreateWaveformFromFileHWSResponse* response) override;
   ::grpc::Status CreateWaveformI16(::grpc::ServerContext* context, const CreateWaveformI16Request* request, CreateWaveformI16Response* response) override;
   ::grpc::Status CreateWaveformFromFileI16(::grpc::ServerContext* context, const CreateWaveformFromFileI16Request* request, CreateWaveformFromFileI16Response* response) override;
   ::grpc::Status DefineUserStandardWaveform(::grpc::ServerContext* context, const DefineUserStandardWaveformRequest* request, DefineUserStandardWaveformResponse* response) override;
@@ -123,13 +119,8 @@ public:
   ::grpc::Status ImportAttributeConfigurationBuffer(::grpc::ServerContext* context, const ImportAttributeConfigurationBufferRequest* request, ImportAttributeConfigurationBufferResponse* response) override;
   ::grpc::Status ImportAttributeConfigurationFile(::grpc::ServerContext* context, const ImportAttributeConfigurationFileRequest* request, ImportAttributeConfigurationFileResponse* response) override;
   ::grpc::Status Init(::grpc::ServerContext* context, const InitRequest* request, InitResponse* response) override;
-  ::grpc::Status InitExtCal(::grpc::ServerContext* context, const InitExtCalRequest* request, InitExtCalResponse* response) override;
   ::grpc::Status InitWithOptions(::grpc::ServerContext* context, const InitWithOptionsRequest* request, InitWithOptionsResponse* response) override;
   ::grpc::Status InitializeWithChannels(::grpc::ServerContext* context, const InitializeWithChannelsRequest* request, InitializeWithChannelsResponse* response) override;
-  ::grpc::Status InitializeAnalogOutputCalibration(::grpc::ServerContext* context, const InitializeAnalogOutputCalibrationRequest* request, InitializeAnalogOutputCalibrationResponse* response) override;
-  ::grpc::Status InitializeCalADCCalibration(::grpc::ServerContext* context, const InitializeCalADCCalibrationRequest* request, InitializeCalADCCalibrationResponse* response) override;
-  ::grpc::Status InitializeFlatnessCalibration(::grpc::ServerContext* context, const InitializeFlatnessCalibrationRequest* request, InitializeFlatnessCalibrationResponse* response) override;
-  ::grpc::Status InitializeOscillatorFrequencyCalibration(::grpc::ServerContext* context, const InitializeOscillatorFrequencyCalibrationRequest* request, InitializeOscillatorFrequencyCalibrationResponse* response) override;
   ::grpc::Status InitiateGeneration(::grpc::ServerContext* context, const InitiateGenerationRequest* request, InitiateGenerationResponse* response) override;
   ::grpc::Status InvalidateAllAttributes(::grpc::ServerContext* context, const InvalidateAllAttributesRequest* request, InvalidateAllAttributesResponse* response) override;
   ::grpc::Status IsDone(::grpc::ServerContext* context, const IsDoneRequest* request, IsDoneResponse* response) override;
@@ -138,7 +129,6 @@ public:
   ::grpc::Status QueryArbSeqCapabilities(::grpc::ServerContext* context, const QueryArbSeqCapabilitiesRequest* request, QueryArbSeqCapabilitiesResponse* response) override;
   ::grpc::Status QueryArbWfmCapabilities(::grpc::ServerContext* context, const QueryArbWfmCapabilitiesRequest* request, QueryArbWfmCapabilitiesResponse* response) override;
   ::grpc::Status QueryFreqListCapabilities(::grpc::ServerContext* context, const QueryFreqListCapabilitiesRequest* request, QueryFreqListCapabilitiesResponse* response) override;
-  ::grpc::Status ReadCalADC(::grpc::ServerContext* context, const ReadCalADCRequest* request, ReadCalADCResponse* response) override;
   ::grpc::Status ReadCurrentTemperature(::grpc::ServerContext* context, const ReadCurrentTemperatureRequest* request, ReadCurrentTemperatureResponse* response) override;
   ::grpc::Status Reset(::grpc::ServerContext* context, const ResetRequest* request, ResetResponse* response) override;
   ::grpc::Status ResetAttribute(::grpc::ServerContext* context, const ResetAttributeRequest* request, ResetAttributeResponse* response) override;
@@ -162,7 +152,6 @@ public:
   ::grpc::Status SetWaveformNextWritePosition(::grpc::ServerContext* context, const SetWaveformNextWritePositionRequest* request, SetWaveformNextWritePositionResponse* response) override;
   ::grpc::Status UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response) override;
   ::grpc::Status WaitUntilDone(::grpc::ServerContext* context, const WaitUntilDoneRequest* request, WaitUntilDoneResponse* response) override;
-  ::grpc::Status WriteBinary16AnalogStaticValue(::grpc::ServerContext* context, const WriteBinary16AnalogStaticValueRequest* request, WriteBinary16AnalogStaticValueResponse* response) override;
   ::grpc::Status WriteBinary16Waveform(::grpc::ServerContext* context, const WriteBinary16WaveformRequest* request, WriteBinary16WaveformResponse* response) override;
   ::grpc::Status WriteComplexBinary16Waveform(::grpc::ServerContext* context, const WriteComplexBinary16WaveformRequest* request, WriteComplexBinary16WaveformResponse* response) override;
   ::grpc::Status WriteNamedWaveformF64(::grpc::ServerContext* context, const WriteNamedWaveformF64Request* request, WriteNamedWaveformF64Response* response) override;

--- a/source/codegen/metadata/nifgen/CHANGES.md
+++ b/source/codegen/metadata/nifgen/CHANGES.md
@@ -50,6 +50,25 @@ The following functions removed as they are obsolete:
 - ConfigureUpdateClockSource
 - SendSoftwareTrigger
 
+The following Calibration functions were removed as we are not supporting them in gRPC :
+- `'InitExtCal'`
+- `'CloseExtCal'`
+- `'InitializeAnalogOutputCalibration'`
+- `'WriteBinary16AnalogStaticValue'`
+- `'CalAdjustMainPathPreAmpOffset'`
+- `'CalAdjustMainPathPreAmpGain'`
+- `'CalAdjustMainPathPostAmpGainAndOffset'`
+- `'CalAdjustDirectPathGain'`
+- `'CalAdjustMainPathOutputImpedance'`
+- `'CalAdjustDirectPathOutputImpedance'`
+- `'InitializeOscillatorFrequencyCalibration'`
+- `'CalAdjustOscillatorFrequency'`
+- `'InitializeCalADCCalibration'`
+- `'CalAdjustAdc'`
+- `'ReadCalADC'`
+- `'InitializeFlatnessCalibration'`
+- `'CalAdjustFlatness'`
+
 ## attributes.py
 
 Following attributes missing in attributes.hapigen, taken from constants.hapigen:

--- a/source/codegen/metadata/nifgen/functions.py
+++ b/source/codegen/metadata/nifgen/functions.py
@@ -74,96 +74,6 @@ functions = {
         ],
         'returns':'ViStatus'
     },
-    'CalAdjustDirectPathOutputImpedance':{
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
-                'type':'ViSession'
-            },
-            {
-                'name':'channelName',
-                'direction':'in',
-                'type':'ViConstString'
-            },
-            {
-                'name':'configuration',
-                'direction':'in',
-                'type':'ViInt32'
-            },
-            {
-                'name':'loadImpedance',
-                'direction':'in',
-                'type':'ViReal64'
-            },
-            {
-                'name':'measuredSourceVoltage',
-                'direction':'in',
-                'type':'ViReal64'
-            },
-            {
-                'name':'measuredVoltageAcrossLoad',
-                'direction':'in',
-                'type':'ViReal64'
-            }
-        ],
-        'returns':'ViStatus'
-    },
-    'CalAdjustMainPathOutputImpedance':{
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
-                'type':'ViSession'
-            },
-            {
-                'name':'channelName',
-                'direction':'in',
-                'type':'ViConstString'
-            },
-            {
-                'name':'configuration',
-                'direction':'in',
-                'type':'ViInt32'
-            },
-            {
-                'name':'loadImpedance',
-                'direction':'in',
-                'type':'ViReal64'
-            },
-            {
-                'name':'measuredSourceVoltage',
-                'direction':'in',
-                'type':'ViReal64'
-            },
-            {
-                'name':'measuredVoltageAcrossLoad',
-                'direction':'in',
-                'type':'ViReal64'
-            }
-        ],
-        'returns':'ViStatus'
-    },
-    'CalAdjustOscillatorFrequency':{
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
-                'type':'ViSession'
-            },
-            {
-                'name':'desiredFrequency',
-                'direction':'in',
-                'type':'ViReal64'
-            },
-            {
-                'name':'measuredFrequency',
-                'direction':'in',
-                'type':'ViReal64'
-            }
-        ],
-        'returns':'ViStatus'
-    },
     'ChangeExtCalPassword':{
         'parameters':[
             {
@@ -431,22 +341,6 @@ functions = {
                 'name':'vi',
                 'direction':'in',
                 'type':'ViSession'
-            }
-        ],
-        'returns':'ViStatus'
-    },
-    'CloseExtCal':{
-        'custom_close_method': True,
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
-                'type':'ViSession'
-            },
-            {
-                'name':'action',
-                'direction':'in',
-                'type':'ViInt32'
             }
         ],
         'returns':'ViStatus'
@@ -2224,28 +2118,6 @@ functions = {
         ],
         'returns': 'ViStatus',
     },
-    'InitExtCal':{
-        'init_method' : True,
-        'custom_close': 'CloseExtCal(id, NIFGEN_VAL_EXT_CAL_ABORT)',
-        'parameters':[
-            {
-                'name':'resourceName',
-                'direction':'in',
-                'type':'ViRsrc'
-            },
-            {
-                'name':'password',
-                'direction':'in',
-                'type':'ViConstString'
-            },
-            {
-                'name':'vi',
-                'direction':'out',
-                'type':'ViSession'
-            }
-        ],
-        'returns':'ViStatus'
-    },
     'InitWithOptions':{
         'init_method' : True,
         'parameters':[
@@ -2303,46 +2175,6 @@ functions = {
             {
                 'name':'vi',
                 'direction':'out',
-                'type':'ViSession'
-            }
-        ],
-        'returns':'ViStatus'
-    },
-    'InitializeAnalogOutputCalibration':{
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
-                'type':'ViSession'
-            }
-        ],
-        'returns':'ViStatus'
-    },
-    'InitializeCalADCCalibration':{
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
-                'type':'ViSession'
-            }
-        ],
-        'returns':'ViStatus'
-    },
-    'InitializeFlatnessCalibration':{
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
-                'type':'ViSession'
-            }
-        ],
-        'returns':'ViStatus'
-    },
-    'InitializeOscillatorFrequencyCalibration':{
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
                 'type':'ViSession'
             }
         ],
@@ -2507,31 +2339,6 @@ functions = {
             },
             {
                 'name':'frequencyListDurationQuantum',
-                'direction':'out',
-                'type':'ViReal64'
-            }
-        ],
-        'returns':'ViStatus'
-    },
-    'ReadCalADC':{
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
-                'type':'ViSession'
-            },
-            {
-                'name':'numberOfReadsToAverage',
-                'direction':'in',
-                'type':'ViInt32'
-            },
-            {
-                'name':'returnCalibratedValue',
-                'direction':'in',
-                'type':'ViBoolean'
-            },
-            {
-                'name':'calAdcValue',
                 'direction':'out',
                 'type':'ViReal64'
             }
@@ -2987,26 +2794,6 @@ functions = {
                 'name':'maxTime',
                 'direction':'in',
                 'type':'ViInt32'
-            }
-        ],
-        'returns':'ViStatus'
-    },
-    'WriteBinary16AnalogStaticValue':{
-        'parameters':[
-            {
-                'name':'vi',
-                'direction':'in',
-                'type':'ViSession'
-            },
-            {
-                'name':'channelName',
-                'direction':'in',
-                'type':'ViConstString'
-            },
-            {
-                'name':'value',
-                'direction':'in',
-                'type':'ViInt16'
             }
         ],
         'returns':'ViStatus'


### PR DESCRIPTION
### What does this Pull Request accomplish?
The driver experts suggested that we shouldnt be adding gRPC support for external calibration. This is because calibration is supported only in LabVIEW and sometimes C. Customers cannot calibrate using C# or Python. Adding the functions to gRPC would convey a confusing message that they are supported. More details on this can be found [here](https://teams.microsoft.com/l/message/19:cc41e50c8bd24404b76b18d15a94fd59@thread.tacv2/1623146640097?tenantId=87ba1f9a-44cd-43a6-b008-6fdb45a5204e&groupId=356e6d01-468c-490e-a5dd-0d07b7783caa&parentMessageId=1623146640097&teamName=DSW&channelName=Modular%20Instruments%20(MI)&createdTime=1623146640097).
Hence, APIs that are used to perform external calibration are removed. Self calibration and calibration utility APIs are retained as is (this was also suggested by driver experts [here](https://teams.microsoft.com/l/message/19:cc41e50c8bd24404b76b18d15a94fd59@thread.tacv2/1623253916691?tenantId=87ba1f9a-44cd-43a6-b008-6fdb45a5204e&groupId=356e6d01-468c-490e-a5dd-0d07b7783caa&parentMessageId=1623253916691&teamName=DSW&channelName=Modular%20Instruments%20(MI)&createdTime=1623253916691)).I have removed the metadata from functions.py and recorded these deletions in CHANGES.md

Out of 17 APIs that we are excluding, only 11 APIs are removed from the proto and generated files since we had not yet added the following 6 APIs : 
- CalAdjustMainPathPreAmpOffset
- CalAdjustDirectPathGain
- CalAdjustFlatness
- CalAdjustMainPathPostAmpGainAndOffset
- CalAdjustMainPathPreAmpGain
- CalAdjustAdc

### Why should this Pull Request be merged?
The APIs marked in red are retained. 

![image](https://user-images.githubusercontent.com/47028785/121508679-7ca78c80-ca03-11eb-91f9-125b2d2f7082.png)

### What testing has been done?
Auto generated the proto and server handlers. Local build is passing.
